### PR TITLE
Implement basic forms and API calls

### DIFF
--- a/backend/routes/api.js
+++ b/backend/routes/api.js
@@ -1,8 +1,53 @@
 const express = require("express");
 const router = express.Router();
 
+let dummyUser = null;
+
 router.get("/ping", (req, res) => {
   res.send("pong");
+});
+
+router.post("/register", (req, res) => {
+  dummyUser = { id: 1, ...req.body };
+  res.json({ message: "registered", user: dummyUser });
+});
+
+router.post("/login", (req, res) => {
+  if (
+    dummyUser &&
+    req.body.email === dummyUser.email &&
+    req.body.password === dummyUser.password
+  ) {
+    return res.json({
+      message: "login success",
+      token: "dummy-token",
+      user: dummyUser,
+    });
+  }
+  res.status(401).json({ message: "invalid credentials" });
+});
+
+router.get("/insurances", (req, res) => {
+  res.json([
+    { id: 1, name: "Seguro Básico" },
+    { id: 2, name: "Seguro Premium" },
+  ]);
+});
+
+router.post("/recommendations", (req, res) => {
+  res.json([{ id: 2, name: "Seguro Premium" }]);
+});
+
+router.post("/policy", (req, res) => {
+  res.json({ message: "policy uploaded" });
+});
+
+router.get("/profile", (req, res) => {
+  if (!dummyUser) return res.status(401).json({ message: "not logged in" });
+  res.json({
+    user: dummyUser,
+    quotes: [{ id: 101, insurance: "Seguro Premium" }],
+  });
 });
 
 module.exports = router;

--- a/frontend/src/AuthContext.jsx
+++ b/frontend/src/AuthContext.jsx
@@ -1,0 +1,46 @@
+import React, { createContext, useState } from 'react';
+
+export const AuthContext = createContext();
+
+export function AuthProvider({ children }) {
+  const [user, setUser] = useState(null);
+  const [token, setToken] = useState(null);
+
+  const register = async (data) => {
+    const res = await fetch('http://localhost:5000/api/register', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(data),
+    });
+    const json = await res.json();
+    if (res.ok) {
+      setUser(json.user);
+    }
+    return json;
+  };
+
+  const login = async (data) => {
+    const res = await fetch('http://localhost:5000/api/login', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(data),
+    });
+    const json = await res.json();
+    if (res.ok) {
+      setUser(json.user);
+      setToken(json.token);
+    }
+    return json;
+  };
+
+  const fetchProfile = async () => {
+    const res = await fetch('http://localhost:5000/api/profile');
+    return res.json();
+  };
+
+  return (
+    <AuthContext.Provider value={{ user, token, register, login, fetchProfile }}>
+      {children}
+    </AuthContext.Provider>
+  );
+}

--- a/frontend/src/main.jsx
+++ b/frontend/src/main.jsx
@@ -2,9 +2,12 @@ import React from 'react';
 import ReactDOM from 'react-dom/client';
 import App from './App.jsx';
 import './index.css';
+import { AuthProvider } from './AuthContext.jsx';
 
 ReactDOM.createRoot(document.getElementById('root')).render(
   <React.StrictMode>
-    <App />
+    <AuthProvider>
+      <App />
+    </AuthProvider>
   </React.StrictMode>
 );

--- a/frontend/src/pages/Compare.jsx
+++ b/frontend/src/pages/Compare.jsx
@@ -1,3 +1,43 @@
+import { useState } from 'react';
+
 export default function Compare() {
-  return <h1 className='text-2xl font-bold p-6 text-center'>Comparador de Seguros</h1>;
+  const [keyword, setKeyword] = useState('');
+  const [results, setResults] = useState([]);
+
+  const handleSearch = async (e) => {
+    e.preventDefault();
+    const res = await fetch('http://localhost:5000/api/insurances');
+    const data = await res.json();
+    if (keyword) {
+      setResults(data.filter((i) => i.name.toLowerCase().includes(keyword.toLowerCase())));
+    } else {
+      setResults(data);
+    }
+  };
+
+  return (
+    <div className="p-6">
+      <h1 className="text-2xl font-bold mb-4 text-center">Comparador de Seguros</h1>
+      <form onSubmit={handleSearch} className="space-y-4 max-w-sm mx-auto">
+        <input
+          className="border p-2 w-full"
+          placeholder="Filtrar por palabra clave"
+          value={keyword}
+          onChange={(e) => setKeyword(e.target.value)}
+        />
+        <button className="bg-blue-500 text-white px-4 py-2 rounded" type="submit">
+          Buscar
+        </button>
+      </form>
+      {results.length > 0 && (
+        <ul className="mt-4 space-y-2">
+          {results.map((r) => (
+            <li key={r.id} className="border p-2">
+              {r.name}
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  );
 }

--- a/frontend/src/pages/Login.jsx
+++ b/frontend/src/pages/Login.jsx
@@ -1,3 +1,40 @@
+import { useContext, useState } from 'react';
+import { AuthContext } from '../AuthContext.jsx';
+
 export default function Login() {
-  return <h1 className='text-2xl font-bold p-6 text-center'>Pantalla de Login</h1>;
+  const { login } = useContext(AuthContext);
+  const [email, setEmail] = useState('');
+  const [password, setPassword] = useState('');
+  const [message, setMessage] = useState('');
+
+  const handleSubmit = async (e) => {
+    e.preventDefault();
+    const res = await login({ email, password });
+    setMessage(res.message);
+  };
+
+  return (
+    <div className="p-6">
+      <h1 className="text-2xl font-bold mb-4 text-center">Login</h1>
+      <form onSubmit={handleSubmit} className="space-y-4 max-w-sm mx-auto">
+        <input
+          className="border p-2 w-full"
+          placeholder="Email"
+          value={email}
+          onChange={(e) => setEmail(e.target.value)}
+        />
+        <input
+          className="border p-2 w-full"
+          type="password"
+          placeholder="Password"
+          value={password}
+          onChange={(e) => setPassword(e.target.value)}
+        />
+        <button className="bg-blue-500 text-white px-4 py-2 rounded" type="submit">
+          Entrar
+        </button>
+      </form>
+      {message && <p className="mt-4 text-center">{message}</p>}
+    </div>
+  );
 }

--- a/frontend/src/pages/Profile.jsx
+++ b/frontend/src/pages/Profile.jsx
@@ -1,3 +1,36 @@
+import { useContext, useState } from 'react';
+import { AuthContext } from '../AuthContext.jsx';
+
 export default function Profile() {
-  return <h1 className='text-2xl font-bold p-6 text-center'>Perfil de Usuario</h1>;
+  const { user, fetchProfile } = useContext(AuthContext);
+  const [profile, setProfile] = useState(null);
+
+  const loadProfile = async () => {
+    const data = await fetchProfile();
+    setProfile(data);
+  };
+
+  return (
+    <div className="p-6">
+      <h1 className="text-2xl font-bold mb-4 text-center">Perfil de Usuario</h1>
+      {user ? (
+        <p className="mb-4 text-center">Bienvenido, {user.name}</p>
+      ) : (
+        <p className="mb-4 text-center">No has iniciado sesión</p>
+      )}
+      <button className="bg-blue-500 text-white px-4 py-2 rounded mb-4" onClick={loadProfile}>
+        Cargar Perfil
+      </button>
+      {profile && (
+        <div>
+          <h2 className="font-semibold mt-2">Cotizaciones Guardadas</h2>
+          <ul className="list-disc pl-5">
+            {profile.quotes.map((q) => (
+              <li key={q.id}>{q.insurance}</li>
+            ))}
+          </ul>
+        </div>
+      )}
+    </div>
+  );
 }

--- a/frontend/src/pages/Recommendations.jsx
+++ b/frontend/src/pages/Recommendations.jsx
@@ -1,3 +1,29 @@
+import { useEffect, useState } from 'react';
+
 export default function Recommendations() {
-  return <h1 className='text-2xl font-bold p-6 text-center'>Recomendaciones Personalizadas</h1>;
+  const [recs, setRecs] = useState([]);
+
+  useEffect(() => {
+    const fetchRecs = async () => {
+      const res = await fetch('http://localhost:5000/api/recommendations', {
+        method: 'POST',
+      });
+      const data = await res.json();
+      setRecs(data);
+    };
+    fetchRecs();
+  }, []);
+
+  return (
+    <div className="p-6">
+      <h1 className="text-2xl font-bold mb-4 text-center">Recomendaciones Personalizadas</h1>
+      <ul className="space-y-2">
+        {recs.map((r) => (
+          <li key={r.id} className="border p-2">
+            {r.name}
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
 }

--- a/frontend/src/pages/Register.jsx
+++ b/frontend/src/pages/Register.jsx
@@ -1,3 +1,47 @@
+import { useContext, useState } from 'react';
+import { AuthContext } from '../AuthContext.jsx';
+
 export default function Register() {
-  return <h1 className='text-2xl font-bold p-6 text-center'>Pantalla de Registro</h1>;
+  const { register } = useContext(AuthContext);
+  const [name, setName] = useState('');
+  const [email, setEmail] = useState('');
+  const [password, setPassword] = useState('');
+  const [message, setMessage] = useState('');
+
+  const handleSubmit = async (e) => {
+    e.preventDefault();
+    const res = await register({ name, email, password });
+    setMessage(res.message);
+  };
+
+  return (
+    <div className="p-6">
+      <h1 className="text-2xl font-bold mb-4 text-center">Registro</h1>
+      <form onSubmit={handleSubmit} className="space-y-4 max-w-sm mx-auto">
+        <input
+          className="border p-2 w-full"
+          placeholder="Nombre"
+          value={name}
+          onChange={(e) => setName(e.target.value)}
+        />
+        <input
+          className="border p-2 w-full"
+          placeholder="Email"
+          value={email}
+          onChange={(e) => setEmail(e.target.value)}
+        />
+        <input
+          className="border p-2 w-full"
+          type="password"
+          placeholder="Password"
+          value={password}
+          onChange={(e) => setPassword(e.target.value)}
+        />
+        <button className="bg-blue-500 text-white px-4 py-2 rounded" type="submit">
+          Registrarse
+        </button>
+      </form>
+      {message && <p className="mt-4 text-center">{message}</p>}
+    </div>
+  );
 }

--- a/frontend/src/pages/UploadPolicy.jsx
+++ b/frontend/src/pages/UploadPolicy.jsx
@@ -1,3 +1,27 @@
+import { useState } from 'react';
+
 export default function UploadPolicy() {
-  return <h1 className='text-2xl font-bold p-6 text-center'>Cargar Póliza Actual</h1>;
+  const [message, setMessage] = useState('');
+
+  const handleSubmit = async (e) => {
+    e.preventDefault();
+    const res = await fetch('http://localhost:5000/api/policy', {
+      method: 'POST',
+    });
+    const data = await res.json();
+    setMessage(data.message);
+  };
+
+  return (
+    <div className="p-6">
+      <h1 className="text-2xl font-bold mb-4 text-center">Cargar Póliza Actual</h1>
+      <form onSubmit={handleSubmit} className="space-y-4 max-w-sm mx-auto">
+        <input type="file" className="block" />
+        <button className="bg-blue-500 text-white px-4 py-2 rounded" type="submit">
+          Subir
+        </button>
+      </form>
+      {message && <p className="mt-4 text-center">{message}</p>}
+    </div>
+  );
 }


### PR DESCRIPTION
## Summary
- add minimal API routes for auth and insurance data
- add React authentication context
- create registration and login forms
- add comparison, recommendations, profile and policy upload pages with API calls
- wrap App in AuthProvider

## Testing
- `npm run build` *(fails: You installed esbuild for another platform)*
- `npm start` in backend

------
https://chatgpt.com/codex/tasks/task_e_6853129038cc832d9e8c17419699c4bf