### PR TITLE
Add basic forms and API endpoints

### DIFF
--- a/backend/routes/api.js
+++ b/backend/routes/api.js
@@ -5,4 +5,42 @@ router.get("/ping", (req, res) => {
   res.send("pong");
 });
 
+router.post("/register", (req, res) => {
+  const { username } = req.body;
+  // In a real app you would save the user to a database
+  res.json({ message: "User registered", user: { username } });
+});
+
+router.post("/login", (req, res) => {
+  const { username } = req.body;
+  // Normally you'd validate the password and generate a token
+  res.json({ message: "Logged in", token: "dummy-token", user: { username } });
+});
+
+router.get("/insurances", (req, res) => {
+  const { query } = req.query;
+  const baseList = [
+    { id: 1, name: "Seguro Básico" },
+    { id: 2, name: "Seguro Premium" },
+    { id: 3, name: "Seguro Familiar" },
+  ];
+  const filtered = query
+    ? baseList.filter((i) => i.name.toLowerCase().includes(query.toLowerCase()))
+    : baseList;
+  res.json(filtered);
+});
+
+router.get("/recommendations", (req, res) => {
+  // Would normally use the user's profile to generate recommendations
+  res.json([
+    { id: 101, name: "Seguro Recomendado 1" },
+    { id: 102, name: "Seguro Recomendado 2" },
+  ]);
+});
+
+router.post("/upload", (req, res) => {
+  // Simulate file upload handling
+  res.json({ message: "Policy uploaded" });
+});
+
 module.exports = router;

--- a/frontend/src/contexts/AuthContext.jsx
+++ b/frontend/src/contexts/AuthContext.jsx
@@ -1,0 +1,24 @@
+import { createContext, useState } from 'react';
+
+export const AuthContext = createContext(null);
+
+export function AuthProvider({ children }) {
+  const [user, setUser] = useState(null);
+  const [token, setToken] = useState(null);
+
+  const login = (userData, newToken) => {
+    setUser(userData);
+    setToken(newToken);
+  };
+
+  const logout = () => {
+    setUser(null);
+    setToken(null);
+  };
+
+  return (
+    <AuthContext.Provider value={{ user, token, login, logout }}>
+      {children}
+    </AuthContext.Provider>
+  );
+}

--- a/frontend/src/main.jsx
+++ b/frontend/src/main.jsx
@@ -1,10 +1,13 @@
 import React from 'react';
 import ReactDOM from 'react-dom/client';
 import App from './App.jsx';
+import { AuthProvider } from './contexts/AuthContext.jsx';
 import './index.css';
 
 ReactDOM.createRoot(document.getElementById('root')).render(
   <React.StrictMode>
-    <App />
+    <AuthProvider>
+      <App />
+    </AuthProvider>
   </React.StrictMode>
 );

--- a/frontend/src/pages/Compare.jsx
+++ b/frontend/src/pages/Compare.jsx
@@ -1,3 +1,35 @@
+import { useState } from 'react';
+
 export default function Compare() {
-  return <h1 className='text-2xl font-bold p-6 text-center'>Comparador de Seguros</h1>;
+  const [query, setQuery] = useState('');
+  const [insurances, setInsurances] = useState([]);
+
+  const handleSearch = async (e) => {
+    e.preventDefault();
+    const res = await fetch(`http://localhost:5000/api/insurances?query=${encodeURIComponent(query)}`);
+    const data = await res.json();
+    setInsurances(data);
+  };
+
+  return (
+    <div className='p-6'>
+      <h1 className='text-2xl font-bold mb-4 text-center'>Comparar Seguros</h1>
+      <form onSubmit={handleSearch} className='flex gap-2 max-w-md mx-auto mb-4'>
+        <input
+          className='border flex-1 p-2'
+          placeholder='Buscar seguro'
+          value={query}
+          onChange={(e) => setQuery(e.target.value)}
+        />
+        <button className='bg-blue-500 text-white px-4 py-2' type='submit'>Buscar</button>
+      </form>
+      <ul className='max-w-md mx-auto space-y-2'>
+        {insurances.map((ins) => (
+          <li key={ins.id} className='border p-2 rounded'>
+            {ins.name}
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
 }

--- a/frontend/src/pages/Login.jsx
+++ b/frontend/src/pages/Login.jsx
@@ -1,3 +1,50 @@
+import { useState, useContext } from 'react';
+import { AuthContext } from '../contexts/AuthContext.jsx';
+
 export default function Login() {
-  return <h1 className='text-2xl font-bold p-6 text-center'>Pantalla de Login</h1>;
+  const { login } = useContext(AuthContext);
+  const [username, setUsername] = useState('');
+  const [password, setPassword] = useState('');
+  const [error, setError] = useState('');
+
+  const handleSubmit = async (e) => {
+    e.preventDefault();
+    const res = await fetch('http://localhost:5000/api/login', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ username, password }),
+    });
+    const data = await res.json();
+    if (data.token) {
+      login(data.user, data.token);
+      setError('');
+    } else {
+      setError('Credenciales inválidas');
+    }
+  };
+
+  return (
+    <div className='p-6'>
+      <h1 className='text-2xl font-bold mb-4 text-center'>Login</h1>
+      <form onSubmit={handleSubmit} className='space-y-4 max-w-sm mx-auto'>
+        <input
+          className='border w-full p-2'
+          placeholder='Usuario'
+          value={username}
+          onChange={(e) => setUsername(e.target.value)}
+        />
+        <input
+          className='border w-full p-2'
+          type='password'
+          placeholder='Contraseña'
+          value={password}
+          onChange={(e) => setPassword(e.target.value)}
+        />
+        <button className='bg-blue-500 text-white px-4 py-2' type='submit'>
+          Iniciar sesión
+        </button>
+      </form>
+      {error && <p className='mt-4 text-center text-red-500'>{error}</p>}
+    </div>
+  );
 }

--- a/frontend/src/pages/Profile.jsx
+++ b/frontend/src/pages/Profile.jsx
@@ -1,3 +1,21 @@
+import { useContext } from 'react';
+import { AuthContext } from '../contexts/AuthContext.jsx';
+
 export default function Profile() {
-  return <h1 className='text-2xl font-bold p-6 text-center'>Perfil de Usuario</h1>;
+  const { user, logout } = useContext(AuthContext);
+  return (
+    <div className='p-6 text-center'>
+      <h1 className='text-2xl font-bold mb-4'>Perfil de Usuario</h1>
+      {user ? (
+        <>
+          <p className='mb-4'>Usuario: {user.username}</p>
+          <button onClick={logout} className='bg-red-500 text-white px-4 py-2'>
+            Cerrar sesión
+          </button>
+        </>
+      ) : (
+        <p>No has iniciado sesión</p>
+      )}
+    </div>
+  );
 }

--- a/frontend/src/pages/Recommendations.jsx
+++ b/frontend/src/pages/Recommendations.jsx
@@ -1,3 +1,24 @@
+import { useEffect, useState } from 'react';
+
 export default function Recommendations() {
-  return <h1 className='text-2xl font-bold p-6 text-center'>Recomendaciones Personalizadas</h1>;
+  const [list, setList] = useState([]);
+
+  useEffect(() => {
+    fetch('http://localhost:5000/api/recommendations')
+      .then((res) => res.json())
+      .then(setList);
+  }, []);
+
+  return (
+    <div className='p-6'>
+      <h1 className='text-2xl font-bold mb-4 text-center'>Recomendaciones</h1>
+      <ul className='max-w-md mx-auto space-y-2'>
+        {list.map((item) => (
+          <li key={item.id} className='border p-2 rounded'>
+            {item.name}
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
 }

--- a/frontend/src/pages/Register.jsx
+++ b/frontend/src/pages/Register.jsx
@@ -1,3 +1,48 @@
+import { useState, useContext } from 'react';
+import { AuthContext } from '../contexts/AuthContext.jsx';
+
 export default function Register() {
-  return <h1 className='text-2xl font-bold p-6 text-center'>Pantalla de Registro</h1>;
+  const { login } = useContext(AuthContext);
+  const [username, setUsername] = useState('');
+  const [password, setPassword] = useState('');
+  const [message, setMessage] = useState('');
+
+  const handleSubmit = async (e) => {
+    e.preventDefault();
+    const res = await fetch('http://localhost:5000/api/register', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ username, password }),
+    });
+    const data = await res.json();
+    setMessage(data.message);
+    if (data.user) {
+      login(data.user, 'dummy-token');
+    }
+  };
+
+  return (
+    <div className='p-6'>
+      <h1 className='text-2xl font-bold mb-4 text-center'>Registro</h1>
+      <form onSubmit={handleSubmit} className='space-y-4 max-w-sm mx-auto'>
+        <input
+          className='border w-full p-2'
+          placeholder='Usuario'
+          value={username}
+          onChange={(e) => setUsername(e.target.value)}
+        />
+        <input
+          className='border w-full p-2'
+          type='password'
+          placeholder='Contraseña'
+          value={password}
+          onChange={(e) => setPassword(e.target.value)}
+        />
+        <button className='bg-blue-500 text-white px-4 py-2' type='submit'>
+          Registrarse
+        </button>
+      </form>
+      {message && <p className='mt-4 text-center'>{message}</p>}
+    </div>
+  );
 }

--- a/frontend/src/pages/UploadPolicy.jsx
+++ b/frontend/src/pages/UploadPolicy.jsx
@@ -1,3 +1,35 @@
+import { useState } from 'react';
+
 export default function UploadPolicy() {
-  return <h1 className='text-2xl font-bold p-6 text-center'>Cargar Póliza Actual</h1>;
+  const [file, setFile] = useState(null);
+  const [message, setMessage] = useState('');
+
+  const handleSubmit = async (e) => {
+    e.preventDefault();
+    if (!file) return;
+    const formData = new FormData();
+    formData.append('file', file);
+    const res = await fetch('http://localhost:5000/api/upload', {
+      method: 'POST',
+      body: formData,
+    });
+    const data = await res.json();
+    setMessage(data.message);
+  };
+
+  return (
+    <div className='p-6'>
+      <h1 className='text-2xl font-bold mb-4 text-center'>Subir Póliza</h1>
+      <form onSubmit={handleSubmit} className='space-y-4 max-w-md mx-auto'>
+        <input
+          type='file'
+          onChange={(e) => setFile(e.target.files[0])}
+        />
+        <button className='bg-blue-500 text-white px-4 py-2' type='submit'>
+          Subir
+        </button>
+      </form>
+      {message && <p className='mt-4 text-center'>{message}</p>}
+    </div>
+  );
 }


### PR DESCRIPTION
## Summary
- add simple backend API routes for auth, insurances, recommendations and upload
- set up React auth context provider
- implement login and register forms using fetch requests
- add insurance search, recommendations list, upload form and profile page

## Testing
- `npm run build` *(fails: esbuild platform mismatch)*

------
https://chatgpt.com/codex/tasks/task_e_685311795458832d82b15fedb8fa2861