### PR TITLE
Add basic MongoDB models and auth routes

### DIFF
--- a/backend/middleware/auth.js
+++ b/backend/middleware/auth.js
@@ -1,0 +1,16 @@
+const jwt = require('jsonwebtoken');
+
+module.exports = function (req, res, next) {
+  const header = req.headers.authorization || '';
+  const token = header.split(' ')[1];
+  if (!token) {
+    return res.status(401).json({ message: 'No token provided' });
+  }
+  try {
+    const decoded = jwt.verify(token, process.env.JWT_SECRET);
+    req.user = decoded;
+    next();
+  } catch (err) {
+    return res.status(401).json({ message: 'Invalid token' });
+  }
+};

--- a/backend/models/Insurance.js
+++ b/backend/models/Insurance.js
@@ -1,0 +1,10 @@
+const mongoose = require('mongoose');
+
+const insuranceSchema = new mongoose.Schema({
+  name: String,
+  type: String,
+  price: Number,
+  details: String
+});
+
+module.exports = mongoose.model('Insurance', insuranceSchema);

--- a/backend/models/Policy.js
+++ b/backend/models/Policy.js
@@ -1,0 +1,11 @@
+const mongoose = require('mongoose');
+
+const policySchema = new mongoose.Schema({
+  user: { type: mongoose.Schema.Types.ObjectId, ref: 'User' },
+  insurance: { type: mongoose.Schema.Types.ObjectId, ref: 'Insurance' },
+  quote: Number,
+  document: String,
+  createdAt: { type: Date, default: Date.now }
+});
+
+module.exports = mongoose.model('Policy', policySchema);

--- a/backend/models/User.js
+++ b/backend/models/User.js
@@ -1,0 +1,11 @@
+const mongoose = require('mongoose');
+
+const userSchema = new mongoose.Schema({
+  name: String,
+  email: { type: String, required: true, unique: true },
+  password: { type: String, required: true },
+  resetToken: String,
+  resetTokenExp: Date
+});
+
+module.exports = mongoose.model('User', userSchema);

--- a/backend/package.json
+++ b/backend/package.json
@@ -6,6 +6,11 @@
   },
   "dependencies": {
     "cors": "^2.8.5",
-    "express": "^4.18.2"
+    "express": "^4.18.2",
+    "bcrypt": "^5.1.0",
+    "dotenv": "^16.3.1",
+    "jsonwebtoken": "^9.0.0",
+    "mongoose": "^7.6.0",
+    "multer": "^1.4.5"
   }
 }

--- a/backend/routes/auth.js
+++ b/backend/routes/auth.js
@@ -1,0 +1,48 @@
+const express = require('express');
+const bcrypt = require('bcrypt');
+const jwt = require('jsonwebtoken');
+const User = require('../models/User');
+
+const router = express.Router();
+
+router.post('/register', async (req, res) => {
+  try {
+    const { email, password, name } = req.body;
+    const hashed = await bcrypt.hash(password, 10);
+    const user = await User.create({ email, password: hashed, name });
+    res.json({ id: user._id, email: user.email });
+  } catch (err) {
+    res.status(400).json({ error: 'Registration failed' });
+  }
+});
+
+router.post('/login', async (req, res) => {
+  try {
+    const { email, password } = req.body;
+    const user = await User.findOne({ email });
+    if (!user) return res.status(400).json({ error: 'Invalid credentials' });
+    const match = await bcrypt.compare(password, user.password);
+    if (!match) return res.status(400).json({ error: 'Invalid credentials' });
+    const token = jwt.sign({ id: user._id }, process.env.JWT_SECRET, { expiresIn: '1h' });
+    res.json({ token });
+  } catch (err) {
+    res.status(500).json({ error: 'Login failed' });
+  }
+});
+
+router.post('/recover', async (req, res) => {
+  try {
+    const { email } = req.body;
+    const user = await User.findOne({ email });
+    if (!user) return res.status(400).json({ error: 'User not found' });
+    const token = Math.random().toString(36).substring(2);
+    user.resetToken = token;
+    user.resetTokenExp = Date.now() + 3600000;
+    await user.save();
+    res.json({ message: 'Recovery token generated' });
+  } catch (err) {
+    res.status(500).json({ error: 'Recovery failed' });
+  }
+});
+
+module.exports = router;

--- a/backend/routes/insurance.js
+++ b/backend/routes/insurance.js
@@ -1,0 +1,18 @@
+const express = require('express');
+const Insurance = require('../models/Insurance');
+
+const router = express.Router();
+
+router.get('/search', async (req, res) => {
+  const q = req.query.q || '';
+  const insurances = await Insurance.find({ name: new RegExp(q, 'i') });
+  res.json(insurances);
+});
+
+router.get('/compare', async (req, res) => {
+  const ids = req.query.ids ? req.query.ids.split(',') : [];
+  const insurances = await Insurance.find({ _id: { $in: ids } });
+  res.json(insurances);
+});
+
+module.exports = router;

--- a/backend/routes/policy.js
+++ b/backend/routes/policy.js
@@ -1,0 +1,38 @@
+const express = require('express');
+const multer = require('multer');
+const Policy = require('../models/Policy');
+const auth = require('../middleware/auth');
+
+const router = express.Router();
+const upload = multer({ dest: 'uploads/' });
+
+router.post('/quote', auth, async (req, res) => {
+  try {
+    const { insurance, quote } = req.body;
+    const policy = await Policy.create({
+      user: req.user.id,
+      insurance,
+      quote
+    });
+    res.json(policy);
+  } catch (err) {
+    res.status(400).json({ error: 'Could not save quote' });
+  }
+});
+
+router.post('/upload', auth, upload.single('file'), async (req, res) => {
+  try {
+    const { insurance, quote } = req.body;
+    const policy = await Policy.create({
+      user: req.user.id,
+      insurance,
+      quote,
+      document: req.file.path
+    });
+    res.json(policy);
+  } catch (err) {
+    res.status(400).json({ error: 'Upload failed' });
+  }
+});
+
+module.exports = router;

--- a/backend/server.js
+++ b/backend/server.js
@@ -1,12 +1,33 @@
-const express = require("express");
-const cors = require("cors");
+const express = require('express');
+const cors = require('cors');
+const mongoose = require('mongoose');
+const dotenv = require('dotenv');
+
+dotenv.config();
+
 const app = express();
-const port = 5000;
-const apiRoutes = require("./routes/api");
+const port = process.env.PORT || 5000;
+
+const apiRoutes = require('./routes/api');
+const authRoutes = require('./routes/auth');
+const insuranceRoutes = require('./routes/insurance');
+const policyRoutes = require('./routes/policy');
 
 app.use(cors());
 app.use(express.json());
-app.use("/api", apiRoutes);
+
+mongoose
+  .connect(process.env.MONGODB_URI, {
+    useNewUrlParser: true,
+    useUnifiedTopology: true
+  })
+  .then(() => console.log('MongoDB connected'))
+  .catch((err) => console.error('MongoDB connection error:', err));
+
+app.use('/api', apiRoutes);
+app.use('/api/auth', authRoutes);
+app.use('/api/insurance', insuranceRoutes);
+app.use('/api/policy', policyRoutes);
 
 app.listen(port, () => {
   console.log(`Servidor backend corriendo en http://localhost:${port}`);


### PR DESCRIPTION
## Summary
- install mongoose, jsonwebtoken, bcrypt and other backend deps
- connect backend to MongoDB with dotenv
- add User, Insurance and Policy models
- create authentication, insurance and policy routes
- add JWT auth middleware

## Testing
- `npm test --silent`
- `npm start --silent` *(fails: Cannot find module 'mongoose')*

------
https://chatgpt.com/codex/tasks/task_e_685310d85cec832da1a93ba08b3d07e4