### PR TITLE
Implement user auth and insurance search

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+node_modules/
+.env
+dist/
+coverage/
+.DS_Store

--- a/backend/config/db.js
+++ b/backend/config/db.js
@@ -1,0 +1,15 @@
+const mongoose = require('mongoose');
+
+async function connectDB() {
+  try {
+    await mongoose.connect(process.env.MONGODB_URI, {
+      useNewUrlParser: true,
+      useUnifiedTopology: true,
+    });
+    console.log('MongoDB connected');
+  } catch (err) {
+    console.error('MongoDB connection error:', err);
+  }
+}
+
+module.exports = connectDB;

--- a/backend/controllers/segurosController.js
+++ b/backend/controllers/segurosController.js
@@ -1,0 +1,32 @@
+const Insurance = require('../models/Insurance');
+
+exports.buscar = async (req, res) => {
+  const { tipo, precioMin, precioMax, cobertura } = req.query;
+  const filtro = {};
+  if (tipo) filtro.type = tipo;
+  if (precioMin || precioMax) filtro.price = {};
+  if (precioMin) filtro.price.$gte = Number(precioMin);
+  if (precioMax) filtro.price.$lte = Number(precioMax);
+  if (cobertura) filtro.coverage = new RegExp(cobertura, 'i');
+  try {
+    const seguros = await Insurance.find(filtro);
+    res.json(seguros);
+  } catch (err) {
+    res.status(500).json({ error: 'Error al buscar seguros' });
+  }
+};
+
+exports.recomendar = async (req, res) => {
+  const { edad, tipo } = req.body;
+  const filtro = {};
+  if (tipo) filtro.type = tipo;
+  try {
+    let seguros = await Insurance.find(filtro).limit(5);
+    if (edad) {
+      seguros = seguros.filter(s => !s.edadMin || s.edadMin <= edad);
+    }
+    res.json(seguros);
+  } catch (err) {
+    res.status(500).json({ error: 'Error al recomendar seguros' });
+  }
+};

--- a/backend/controllers/usuariosController.js
+++ b/backend/controllers/usuariosController.js
@@ -1,0 +1,50 @@
+const bcrypt = require('bcrypt');
+const jwt = require('jsonwebtoken');
+const User = require('../models/User');
+
+function validarPassword(pass) {
+  return /[A-Za-z]/.test(pass) && /\d/.test(pass) && pass.length >= 8;
+}
+
+exports.registrar = async (req, res) => {
+  const { nombre, correo, password } = req.body;
+  if (!nombre || !correo || !password) {
+    return res.status(400).json({ error: 'Todos los campos son obligatorios' });
+  }
+  if (!validarPassword(password)) {
+    return res.status(400).json({ error: 'Contrase\u00f1a d\u00e9bil' });
+  }
+  try {
+    const existente = await User.findOne({ email: correo });
+    if (existente) {
+      return res.status(400).json({ error: 'Correo ya registrado' });
+    }
+    const hashed = await bcrypt.hash(password, 10);
+    const user = await User.create({ name: nombre, email: correo, password: hashed });
+    console.log(`Enviar correo de confirmaci\u00f3n a ${correo}`);
+    res.json({ user: { id: user._id, name: user.name, email: user.email } });
+  } catch (err) {
+    res.status(500).json({ error: 'Error al registrar usuario' });
+  }
+};
+
+exports.login = async (req, res) => {
+  const { correo, password } = req.body;
+  if (!correo || !password) {
+    return res.status(400).json({ error: 'Datos incompletos' });
+  }
+  try {
+    const user = await User.findOne({ email: correo });
+    if (!user) {
+      return res.status(400).json({ error: 'Credenciales inv\u00e1lidas' });
+    }
+    const match = await bcrypt.compare(password, user.password);
+    if (!match) {
+      return res.status(400).json({ error: 'Credenciales inv\u00e1lidas' });
+    }
+    const token = jwt.sign({ id: user._id }, process.env.JWT_SECRET, { expiresIn: '30m' });
+    res.json({ token, user: { id: user._id, name: user.name, email: user.email } });
+  } catch (err) {
+    res.status(500).json({ error: 'Error al iniciar sesi\u00f3n' });
+  }
+};

--- a/backend/models/Insurance.js
+++ b/backend/models/Insurance.js
@@ -4,7 +4,9 @@ const insuranceSchema = new mongoose.Schema({
   name: String,
   type: String,
   price: Number,
-  details: String
+  coverage: String,
+  details: String,
+  edadMin: Number
 });
 
 module.exports = mongoose.model('Insurance', insuranceSchema);

--- a/backend/routes/seguros.js
+++ b/backend/routes/seguros.js
@@ -1,0 +1,9 @@
+const express = require('express');
+const { buscar, recomendar } = require('../controllers/segurosController');
+
+const router = express.Router();
+
+router.get('/buscar', buscar);
+router.post('/recomendar', recomendar);
+
+module.exports = router;

--- a/backend/routes/usuarios.js
+++ b/backend/routes/usuarios.js
@@ -1,0 +1,9 @@
+const express = require('express');
+const { registrar, login } = require('../controllers/usuariosController');
+
+const router = express.Router();
+
+router.post('/registrar', registrar);
+router.post('/login', login);
+
+module.exports = router;

--- a/backend/server.js
+++ b/backend/server.js
@@ -1,7 +1,7 @@
 const express = require('express');
 const cors = require('cors');
-const mongoose = require('mongoose');
 const dotenv = require('dotenv');
+const connectDB = require('./config/db');
 
 dotenv.config();
 
@@ -12,22 +12,20 @@ const apiRoutes = require('./routes/api');
 const authRoutes = require('./routes/auth');
 const insuranceRoutes = require('./routes/insurance');
 const policyRoutes = require('./routes/policy');
+const usuariosRoutes = require('./routes/usuarios');
+const segurosRoutes = require('./routes/seguros');
 
 app.use(cors());
 app.use(express.json());
 
-mongoose
-  .connect(process.env.MONGODB_URI, {
-    useNewUrlParser: true,
-    useUnifiedTopology: true
-  })
-  .then(() => console.log('MongoDB connected'))
-  .catch((err) => console.error('MongoDB connection error:', err));
+connectDB();
 
 app.use('/api', apiRoutes);
 app.use('/api/auth', authRoutes);
 app.use('/api/insurance', insuranceRoutes);
 app.use('/api/policy', policyRoutes);
+app.use('/api/usuarios', usuariosRoutes);
+app.use('/api/seguros', segurosRoutes);
 
 app.listen(port, () => {
   console.log(`Servidor backend corriendo en http://localhost:${port}`);

--- a/backend/services/seguroService.js
+++ b/backend/services/seguroService.js
@@ -1,0 +1,3 @@
+const Insurance = require('../models/Insurance');
+exports.search = (filter) => Insurance.find(filter);
+exports.recommend = (filter) => Insurance.find(filter).limit(5);

--- a/backend/services/userService.js
+++ b/backend/services/userService.js
@@ -1,0 +1,2 @@
+const User = require('../models/User');
+exports.findByEmail = (email) => User.findOne({ email });

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -2,10 +2,10 @@ import React from "react";
 import { BrowserRouter as Router, Routes, Route, Link } from "react-router-dom";
 import Home from "./pages/Home.jsx";
 import Login from "./pages/Login.jsx";
-import Register from "./pages/Register.jsx";
-import Compare from "./pages/Compare.jsx";
-import Recommendations from "./pages/Recommendations.jsx";
-import Profile from "./pages/Profile.jsx";
+import Registro from "./pages/Registro.jsx";
+import BuscarSeguros from "./pages/BuscarSeguros.jsx";
+import Recomendaciones from "./pages/Recomendaciones.jsx";
+import Perfil from "./pages/Perfil.jsx";
 import UploadPolicy from "./pages/UploadPolicy.jsx";
 
 function Navbar() {
@@ -14,11 +14,11 @@ function Navbar() {
       <ul className="flex flex-wrap gap-4 text-sm font-medium">
         <li><Link to="/">Inicio</Link></li>
         <li><Link to="/login">Login</Link></li>
-        <li><Link to="/register">Registro</Link></li>
-        <li><Link to="/compare">Comparar</Link></li>
+        <li><Link to="/registro">Registro</Link></li>
+        <li><Link to="/buscar">Buscar Seguros</Link></li>
         <li><Link to="/upload-policy">Subir Póliza</Link></li>
-        <li><Link to="/recommendations">Recomendaciones</Link></li>
-        <li><Link to="/profile">Perfil</Link></li>
+        <li><Link to="/recomendaciones">Recomendaciones</Link></li>
+        <li><Link to="/perfil">Perfil</Link></li>
       </ul>
     </nav>
   );
@@ -31,10 +31,10 @@ function App() {
       <Routes>
         <Route path="/" element={<Home />} />
         <Route path="/login" element={<Login />} />
-        <Route path="/register" element={<Register />} />
-        <Route path="/compare" element={<Compare />} />
-        <Route path="/recommendations" element={<Recommendations />} />
-        <Route path="/profile" element={<Profile />} />
+        <Route path="/registro" element={<Registro />} />
+        <Route path="/buscar" element={<BuscarSeguros />} />
+        <Route path="/recomendaciones" element={<Recomendaciones />} />
+        <Route path="/perfil" element={<Perfil />} />
         <Route path="/upload-policy" element={<UploadPolicy />} />
       </Routes>
     </Router>

--- a/frontend/src/context/UserContext.jsx
+++ b/frontend/src/context/UserContext.jsx
@@ -1,0 +1,24 @@
+import { createContext, useState } from 'react';
+
+export const UserContext = createContext(null);
+
+export function UserProvider({ children }) {
+  const [user, setUser] = useState(null);
+  const [token, setToken] = useState(null);
+
+  const login = (userData, jwt) => {
+    setUser(userData);
+    setToken(jwt);
+  };
+
+  const logout = () => {
+    setUser(null);
+    setToken(null);
+  };
+
+  return (
+    <UserContext.Provider value={{ user, token, login, logout }}>
+      {children}
+    </UserContext.Provider>
+  );
+}

--- a/frontend/src/main.jsx
+++ b/frontend/src/main.jsx
@@ -1,13 +1,13 @@
 import React from 'react';
 import ReactDOM from 'react-dom/client';
 import App from './App.jsx';
-import { AuthProvider } from './contexts/AuthContext.jsx';
+import { UserProvider } from './context/UserContext.jsx';
 import './index.css';
 
 ReactDOM.createRoot(document.getElementById('root')).render(
   <React.StrictMode>
-    <AuthProvider>
+    <UserProvider>
       <App />
-    </AuthProvider>
+    </UserProvider>
   </React.StrictMode>
 );

--- a/frontend/src/pages/BuscarSeguros.jsx
+++ b/frontend/src/pages/BuscarSeguros.jsx
@@ -1,0 +1,40 @@
+import { useState } from 'react';
+
+export default function BuscarSeguros() {
+  const [tipo, setTipo] = useState('');
+  const [precioMin, setPrecioMin] = useState('');
+  const [precioMax, setPrecioMax] = useState('');
+  const [cobertura, setCobertura] = useState('');
+  const [resultados, setResultados] = useState([]);
+
+  const buscar = async () => {
+    const params = new URLSearchParams();
+    if (tipo) params.append('tipo', tipo);
+    if (precioMin) params.append('precioMin', precioMin);
+    if (precioMax) params.append('precioMax', precioMax);
+    if (cobertura) params.append('cobertura', cobertura);
+    const res = await fetch(`http://localhost:5000/api/seguros/buscar?${params.toString()}`);
+    const data = await res.json();
+    setResultados(data);
+  };
+
+  return (
+    <div className='p-6'>
+      <h1 className='text-2xl font-bold mb-4 text-center'>Buscar Seguros</h1>
+      <div className='space-y-2 max-w-md mx-auto mb-4'>
+        <input className='border w-full p-2' placeholder='Tipo' value={tipo} onChange={e=>setTipo(e.target.value)} />
+        <input className='border w-full p-2' placeholder='Precio mínimo' value={precioMin} onChange={e=>setPrecioMin(e.target.value)} />
+        <input className='border w-full p-2' placeholder='Precio máximo' value={precioMax} onChange={e=>setPrecioMax(e.target.value)} />
+        <input className='border w-full p-2' placeholder='Cobertura' value={cobertura} onChange={e=>setCobertura(e.target.value)} />
+        <button className='bg-blue-500 text-white px-4 py-2' onClick={buscar}>Buscar</button>
+      </div>
+      <ul className='space-y-2'>
+        {resultados.map(s => (
+          <li key={s._id} className='border p-2 rounded'>
+            {s.name} - ${s.price}
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}

--- a/frontend/src/pages/Login.jsx
+++ b/frontend/src/pages/Login.jsx
@@ -1,25 +1,25 @@
 import { useState, useContext } from 'react';
-import { AuthContext } from '../contexts/AuthContext.jsx';
+import { UserContext } from '../context/UserContext.jsx';
 
 export default function Login() {
-  const { login } = useContext(AuthContext);
-  const [username, setUsername] = useState('');
+  const { login } = useContext(UserContext);
+  const [correo, setCorreo] = useState('');
   const [password, setPassword] = useState('');
   const [error, setError] = useState('');
 
   const handleSubmit = async (e) => {
     e.preventDefault();
-    const res = await fetch('http://localhost:5000/api/login', {
+    const res = await fetch('http://localhost:5000/api/usuarios/login', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ username, password }),
+      body: JSON.stringify({ correo, password }),
     });
     const data = await res.json();
-    if (data.token) {
+    if (res.ok) {
       login(data.user, data.token);
       setError('');
     } else {
-      setError('Credenciales inválidas');
+      setError(data.error || 'Credenciales inválidas');
     }
   };
 
@@ -29,9 +29,9 @@ export default function Login() {
       <form onSubmit={handleSubmit} className='space-y-4 max-w-sm mx-auto'>
         <input
           className='border w-full p-2'
-          placeholder='Usuario'
-          value={username}
-          onChange={(e) => setUsername(e.target.value)}
+          placeholder='Correo'
+          value={correo}
+          onChange={(e) => setCorreo(e.target.value)}
         />
         <input
           className='border w-full p-2'

--- a/frontend/src/pages/Perfil.jsx
+++ b/frontend/src/pages/Perfil.jsx
@@ -1,0 +1,21 @@
+import { useContext } from 'react';
+import { UserContext } from '../context/UserContext.jsx';
+
+export default function Perfil() {
+  const { user, logout } = useContext(UserContext);
+  return (
+    <div className='p-6 text-center'>
+      <h1 className='text-2xl font-bold mb-4'>Perfil de Usuario</h1>
+      {user ? (
+        <>
+          <p className='mb-4'>Correo: {user.email}</p>
+          <button onClick={logout} className='bg-red-500 text-white px-4 py-2'>
+            Cerrar sesión
+          </button>
+        </>
+      ) : (
+        <p>No has iniciado sesión</p>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/pages/Recomendaciones.jsx
+++ b/frontend/src/pages/Recomendaciones.jsx
@@ -1,0 +1,36 @@
+import { useState } from 'react';
+
+export default function Recomendaciones() {
+  const [edad, setEdad] = useState('');
+  const [tipo, setTipo] = useState('');
+  const [resultados, setResultados] = useState([]);
+
+  const recomendar = async (e) => {
+    e.preventDefault();
+    const res = await fetch('http://localhost:5000/api/seguros/recomendar', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ edad, tipo })
+    });
+    const data = await res.json();
+    setResultados(data);
+  };
+
+  return (
+    <div className='p-6'>
+      <h1 className='text-2xl font-bold mb-4 text-center'>Recomendaciones</h1>
+      <form onSubmit={recomendar} className='space-y-2 max-w-md mx-auto mb-4'>
+        <input className='border w-full p-2' placeholder='Edad' value={edad} onChange={e=>setEdad(e.target.value)} />
+        <input className='border w-full p-2' placeholder='Tipo' value={tipo} onChange={e=>setTipo(e.target.value)} />
+        <button className='bg-blue-500 text-white px-4 py-2' type='submit'>Obtener</button>
+      </form>
+      <ul className='space-y-2'>
+        {resultados.map(s => (
+          <li key={s._id} className='border p-2 rounded'>
+            {s.name} - ${s.price}
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}

--- a/frontend/src/pages/Registro.jsx
+++ b/frontend/src/pages/Registro.jsx
@@ -1,0 +1,52 @@
+import { useState, useContext } from 'react';
+import { UserContext } from '../context/UserContext.jsx';
+
+export default function Registro() {
+  const { login } = useContext(UserContext);
+  const [nombre, setNombre] = useState('');
+  const [correo, setCorreo] = useState('');
+  const [password, setPassword] = useState('');
+  const [error, setError] = useState('');
+
+  const validar = () => {
+    if (!nombre || !correo || !password) return 'Todos los campos son obligatorios';
+    if (!/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(correo)) return 'Correo inválido';
+    if (password.length < 8 || !/\d/.test(password) || !/[A-Za-z]/.test(password)) return 'Contraseña débil';
+    return null;
+  };
+
+  const handleSubmit = async (e) => {
+    e.preventDefault();
+    const msg = validar();
+    if (msg) { setError(msg); return; }
+    try {
+      const res = await fetch('http://localhost:5000/api/usuarios/registrar', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ nombre, correo, password })
+      });
+      const data = await res.json();
+      if (res.ok) {
+        login(data.user, data.token);
+        setError('');
+      } else {
+        setError(data.error || 'Error');
+      }
+    } catch (err) {
+      setError('Error de red');
+    }
+  };
+
+  return (
+    <div className='p-6'>
+      <h1 className='text-2xl font-bold mb-4 text-center'>Registro</h1>
+      <form onSubmit={handleSubmit} className='space-y-4 max-w-sm mx-auto'>
+        <input className='border w-full p-2' placeholder='Nombre' value={nombre} onChange={e=>setNombre(e.target.value)} />
+        <input className='border w-full p-2' placeholder='Correo' value={correo} onChange={e=>setCorreo(e.target.value)} />
+        <input className='border w-full p-2' type='password' placeholder='Contraseña' value={password} onChange={e=>setPassword(e.target.value)} />
+        <button className='bg-blue-500 text-white px-4 py-2' type='submit'>Registrarse</button>
+      </form>
+      {error && <p className='mt-4 text-center text-red-500'>{error}</p>}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- ignore development artifacts
- add MongoDB connection helper and business layer folders
- implement user registration and login controllers
- add seguros controller and routes
- expose new routes from backend server
- support user context in the frontend
- create Registro, BuscarSeguros, Recomendaciones and Perfil pages
- adjust existing Login and routing

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68532ea1b27c832d8e01a1d4adc17b9b