### PR TITLE
Add admin and contact endpoints

### DIFF
--- a/backend/controllers/usuariosController.js
+++ b/backend/controllers/usuariosController.js
@@ -7,7 +7,7 @@ function validarPassword(pass) {
 }
 
 exports.registrar = async (req, res) => {
-  const { nombre, correo, password } = req.body;
+  const { nombre, correo, password, role } = req.body;
   if (!nombre || !correo || !password) {
     return res.status(400).json({ error: 'Todos los campos son obligatorios' });
   }
@@ -20,9 +20,9 @@ exports.registrar = async (req, res) => {
       return res.status(400).json({ error: 'Correo ya registrado' });
     }
     const hashed = await bcrypt.hash(password, 10);
-    const user = await User.create({ name: nombre, email: correo, password: hashed });
+    const user = await User.create({ name: nombre, email: correo, password: hashed, role: role || 'user' });
     console.log(`Enviar correo de confirmaci\u00f3n a ${correo}`);
-    res.json({ user: { id: user._id, name: user.name, email: user.email } });
+    res.json({ user: { id: user._id, name: user.name, email: user.email, role: user.role } });
   } catch (err) {
     res.status(500).json({ error: 'Error al registrar usuario' });
   }
@@ -42,8 +42,8 @@ exports.login = async (req, res) => {
     if (!match) {
       return res.status(400).json({ error: 'Credenciales inv\u00e1lidas' });
     }
-    const token = jwt.sign({ id: user._id }, process.env.JWT_SECRET, { expiresIn: '30m' });
-    res.json({ token, user: { id: user._id, name: user.name, email: user.email } });
+    const token = jwt.sign({ id: user._id, role: user.role }, process.env.JWT_SECRET, { expiresIn: '30m' });
+    res.json({ token, user: { id: user._id, name: user.name, email: user.email, role: user.role } });
   } catch (err) {
     res.status(500).json({ error: 'Error al iniciar sesi\u00f3n' });
   }

--- a/backend/models/ContactMessage.js
+++ b/backend/models/ContactMessage.js
@@ -1,0 +1,10 @@
+const mongoose = require('mongoose');
+
+const contactSchema = new mongoose.Schema({
+  name: String,
+  email: String,
+  message: String,
+  createdAt: { type: Date, default: Date.now }
+});
+
+module.exports = mongoose.model('ContactMessage', contactSchema);

--- a/backend/models/Favorite.js
+++ b/backend/models/Favorite.js
@@ -1,0 +1,8 @@
+const mongoose = require('mongoose');
+
+const favoriteSchema = new mongoose.Schema({
+  user: { type: mongoose.Schema.Types.ObjectId, ref: 'User' },
+  insurance: { type: mongoose.Schema.Types.ObjectId, ref: 'Insurance' }
+});
+
+module.exports = mongoose.model('Favorite', favoriteSchema);

--- a/backend/models/Insurer.js
+++ b/backend/models/Insurer.js
@@ -1,0 +1,8 @@
+const mongoose = require('mongoose');
+
+const insurerSchema = new mongoose.Schema({
+  name: { type: String, required: true },
+  nit: { type: String, required: true, unique: true }
+});
+
+module.exports = mongoose.model('Insurer', insurerSchema);

--- a/backend/models/User.js
+++ b/backend/models/User.js
@@ -5,7 +5,8 @@ const userSchema = new mongoose.Schema({
   email: { type: String, required: true, unique: true },
   password: { type: String, required: true },
   resetToken: String,
-  resetTokenExp: Date
+  resetTokenExp: Date,
+  role: { type: String, default: 'user' }
 });
 
 module.exports = mongoose.model('User', userSchema);

--- a/backend/routes/adminInsurers.js
+++ b/backend/routes/adminInsurers.js
@@ -1,0 +1,46 @@
+const express = require('express');
+const Insurer = require('../models/Insurer');
+const auth = require('../middleware/auth');
+
+const router = express.Router();
+
+router.use(auth, (req, res, next) => {
+  if (req.user.role !== 'admin') {
+    return res.status(403).json({ error: 'No autorizado' });
+  }
+  next();
+});
+
+router.get('/', async (req, res) => {
+  const insurers = await Insurer.find();
+  res.json(insurers);
+});
+
+router.post('/', async (req, res) => {
+  try {
+    const insurer = await Insurer.create(req.body);
+    res.json(insurer);
+  } catch (err) {
+    res.status(400).json({ error: 'Error al crear' });
+  }
+});
+
+router.put('/:id', async (req, res) => {
+  try {
+    const insurer = await Insurer.findByIdAndUpdate(req.params.id, req.body, { new: true });
+    res.json(insurer);
+  } catch (err) {
+    res.status(400).json({ error: 'Error al actualizar' });
+  }
+});
+
+router.delete('/:id', async (req, res) => {
+  try {
+    await Insurer.findByIdAndDelete(req.params.id);
+    res.json({ message: 'Aseguradora eliminada' });
+  } catch (err) {
+    res.status(400).json({ error: 'Error al eliminar' });
+  }
+});
+
+module.exports = router;

--- a/backend/routes/adminUsers.js
+++ b/backend/routes/adminUsers.js
@@ -1,0 +1,38 @@
+const express = require('express');
+const User = require('../models/User');
+const auth = require('../middleware/auth');
+
+const router = express.Router();
+
+// Middleware simple para verificar rol admin
+router.use(auth, (req, res, next) => {
+  if (req.user.role !== 'admin') {
+    return res.status(403).json({ error: 'No autorizado' });
+  }
+  next();
+});
+
+router.get('/', async (req, res) => {
+  const users = await User.find();
+  res.json(users);
+});
+
+router.put('/:id', async (req, res) => {
+  try {
+    const user = await User.findByIdAndUpdate(req.params.id, req.body, { new: true });
+    res.json(user);
+  } catch (err) {
+    res.status(400).json({ error: 'Error al actualizar' });
+  }
+});
+
+router.delete('/:id', async (req, res) => {
+  try {
+    await User.findByIdAndDelete(req.params.id);
+    res.json({ message: 'Usuario eliminado' });
+  } catch (err) {
+    res.status(400).json({ error: 'Error al eliminar' });
+  }
+});
+
+module.exports = router;

--- a/backend/routes/auth.js
+++ b/backend/routes/auth.js
@@ -23,7 +23,7 @@ router.post('/login', async (req, res) => {
     if (!user) return res.status(400).json({ error: 'Invalid credentials' });
     const match = await bcrypt.compare(password, user.password);
     if (!match) return res.status(400).json({ error: 'Invalid credentials' });
-    const token = jwt.sign({ id: user._id }, process.env.JWT_SECRET, { expiresIn: '1h' });
+    const token = jwt.sign({ id: user._id, role: user.role }, process.env.JWT_SECRET, { expiresIn: '1h' });
     res.json({ token });
   } catch (err) {
     res.status(500).json({ error: 'Login failed' });
@@ -37,7 +37,7 @@ router.post('/recover', async (req, res) => {
     if (!user) return res.status(400).json({ error: 'User not found' });
     const token = Math.random().toString(36).substring(2);
     user.resetToken = token;
-    user.resetTokenExp = Date.now() + 3600000;
+    user.resetTokenExp = Date.now() + 24 * 60 * 60 * 1000;
     await user.save();
     res.json({ message: 'Recovery token generated' });
   } catch (err) {

--- a/backend/routes/contact.js
+++ b/backend/routes/contact.js
@@ -1,0 +1,20 @@
+const express = require('express');
+const ContactMessage = require('../models/ContactMessage');
+
+const router = express.Router();
+
+router.post('/', async (req, res) => {
+  const { name, email, message } = req.body;
+  if (!name || !email || !message) {
+    return res.status(400).json({ error: 'Datos incompletos' });
+  }
+  try {
+    const msg = await ContactMessage.create({ name, email, message });
+    console.log(`Nuevo mensaje de contacto de ${email}`);
+    res.json({ id: msg._id });
+  } catch (err) {
+    res.status(500).json({ error: 'Error al enviar mensaje' });
+  }
+});
+
+module.exports = router;

--- a/backend/routes/favorites.js
+++ b/backend/routes/favorites.js
@@ -1,0 +1,48 @@
+const express = require('express');
+const Favorite = require('../models/Favorite');
+const Insurance = require('../models/Insurance');
+const auth = require('../middleware/auth');
+
+const router = express.Router();
+
+router.use(auth);
+
+router.get('/', async (req, res) => {
+  const favs = await Favorite.find({ user: req.user.id }).populate('insurance');
+  res.json(favs);
+});
+
+router.post('/:insuranceId', async (req, res) => {
+  try {
+    const fav = await Favorite.findOneAndUpdate(
+      { user: req.user.id, insurance: req.params.insuranceId },
+      {},
+      { upsert: true, new: true }
+    );
+    res.json(fav);
+  } catch (err) {
+    res.status(400).json({ error: 'Error al agregar favorito' });
+  }
+});
+
+router.delete('/:insuranceId', async (req, res) => {
+  await Favorite.deleteOne({ user: req.user.id, insurance: req.params.insuranceId });
+  res.json({ message: 'Favorito eliminado' });
+});
+
+// Ruta para actualizar precio y notificar
+router.put('/notify/:insuranceId', async (req, res) => {
+  const { price } = req.body;
+  try {
+    const ins = await Insurance.findByIdAndUpdate(req.params.insuranceId, { price }, { new: true });
+    const favs = await Favorite.find({ insurance: ins._id }).populate('user');
+    favs.forEach(f => {
+      console.log(`Notificar a ${f.user.email} cambio de precio en ${ins.name}`);
+    });
+    res.json(ins);
+  } catch (err) {
+    res.status(400).json({ error: 'Error al actualizar precio' });
+  }
+});
+
+module.exports = router;

--- a/backend/server.js
+++ b/backend/server.js
@@ -14,6 +14,10 @@ const insuranceRoutes = require('./routes/insurance');
 const policyRoutes = require('./routes/policy');
 const usuariosRoutes = require('./routes/usuarios');
 const segurosRoutes = require('./routes/seguros');
+const contactRoutes = require('./routes/contact');
+const adminUsersRoutes = require('./routes/adminUsers');
+const adminInsurersRoutes = require('./routes/adminInsurers');
+const favoritesRoutes = require('./routes/favorites');
 
 app.use(cors());
 app.use(express.json());
@@ -26,6 +30,10 @@ app.use('/api/insurance', insuranceRoutes);
 app.use('/api/policy', policyRoutes);
 app.use('/api/usuarios', usuariosRoutes);
 app.use('/api/seguros', segurosRoutes);
+app.use('/api/contact', contactRoutes);
+app.use('/api/admin/users', adminUsersRoutes);
+app.use('/api/admin/insurers', adminInsurersRoutes);
+app.use('/api/favorites', favoritesRoutes);
 
 app.listen(port, () => {
   console.log(`Servidor backend corriendo en http://localhost:${port}`);


### PR DESCRIPTION
## Summary
- add models for contacts, insurers, favorites
- allow user role in users
- create admin routes to manage users and insurers
- implement favorites and contact endpoints
- expose new routes from server

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68533239bc34832d85a17173e27f690f