### PR TITLE
Fix backend port handling and improve frontend features

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -1,2 +1,2 @@
-MONGO_URI=mongodb://localhost/aiseguros
+MONGO_URI=mongodb://localhost:27017/aiseguros
 PORT=5000

--- a/backend/routes/recomendaciones.js
+++ b/backend/routes/recomendaciones.js
@@ -7,6 +7,8 @@ router.post('/', (req, res) => {
   // lógica de ejemplo: filtrar por tipo y precio según edad
   let seguros = mock.filter(s => !tipo || s.tipo === tipo);
   if (edad < 30) seguros = seguros.filter(s => s.precio <= 150);
+  // mezclar para que las recomendaciones cambien
+  seguros = seguros.sort(() => Math.random() - 0.5);
   res.json(seguros.slice(0, 3));
 });
 

--- a/backend/server.js
+++ b/backend/server.js
@@ -6,7 +6,7 @@ const dotenv = require("dotenv");
 dotenv.config();
 
 const app = express();
-const port = process.env.PORT || 5000;
+let port = process.env.PORT ? Number(process.env.PORT) : 5000;
 
 // Rutas
 const authRoutes = require("./routes/auth");
@@ -30,6 +30,20 @@ app.use("/api/recomendaciones", recomendacionesRoutes);
 app.use("/api/polizas", polizasRoutes);
 app.use("/api/contacto", contactoRoutes);
 
-app.listen(port, () => {
-  console.log(`Servidor backend corriendo en http://localhost:${port}`);
-});
+function start(p) {
+  const server = app
+    .listen(p, () => {
+      port = p;
+      console.log(`Servidor backend corriendo en http://localhost:${p}`);
+    })
+    .on("error", (err) => {
+      if (err.code === "EADDRINUSE") {
+        console.log(`Puerto ${p} en uso, intentando ${p + 1}`);
+        start(p + 1);
+      } else {
+        console.error("Error al iniciar servidor", err);
+      }
+    });
+}
+
+start(port);

--- a/backend/utils/mockSeguros.js
+++ b/backend/utils/mockSeguros.js
@@ -1,5 +1,8 @@
 module.exports = [
   { id: 1, name: 'Seguro Básico', tipo: 'auto', precio: 100, cobertura: 'basica' },
   { id: 2, name: 'Seguro Premium', tipo: 'hogar', precio: 200, cobertura: 'amplia' },
-  { id: 3, name: 'Seguro Oro', tipo: 'vida', precio: 300, cobertura: 'total' }
+  { id: 3, name: 'Seguro Oro', tipo: 'vida', precio: 300, cobertura: 'total' },
+  { id: 4, name: 'Seguro Familiar', tipo: 'salud', precio: 180, cobertura: 'amplia' },
+  { id: 5, name: 'Seguro Express', tipo: 'auto', precio: 120, cobertura: 'basica' },
+  { id: 6, name: 'Seguro Hogar Plus', tipo: 'hogar', precio: 250, cobertura: 'total' }
 ];

--- a/frontend/src/pages/Recommendations.jsx
+++ b/frontend/src/pages/Recommendations.jsx
@@ -11,23 +11,41 @@ export default function Recommendations() {
     const res = await fetch('/api/recomendaciones', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify(form)
+      body: JSON.stringify({
+        edad: Number(form.edad),
+        tipo: form.tipo
+      })
     });
     setRecs(await res.json());
   };
 
   return (
-    <div className="p-4">
-      <form onSubmit={handleSubmit} className="flex flex-wrap gap-2 mb-4">
-        <input name="edad" placeholder="Edad" onChange={handleChange} className="border p-1" />
-        <input name="tipo" placeholder="Tipo" onChange={handleChange} className="border p-1" />
-        <button className="bg-blue-500 text-white px-3" type="submit">Obtener</button>
+    <div className="p-4 max-w-xl mx-auto">
+      <form onSubmit={handleSubmit} className="flex flex-col sm:flex-row gap-2 mb-6">
+        <input
+          name="edad"
+          placeholder="Edad"
+          type="number"
+          onChange={handleChange}
+          className="border p-2 rounded flex-1"
+        />
+        <input
+          name="tipo"
+          placeholder="Tipo de seguro"
+          onChange={handleChange}
+          className="border p-2 rounded flex-1"
+        />
+        <button className="bg-blue-500 hover:bg-blue-600 text-white px-4 py-2 rounded" type="submit">Obtener</button>
       </form>
-      <ul>
+      <div className="grid gap-4">
         {recs.map(r => (
-          <li key={r.id} className="border-b py-1">{r.name} - ${r.precio}</li>
+          <div key={r.id} className="border rounded shadow p-4">
+            <h3 className="font-semibold text-lg mb-1">{r.name}</h3>
+            <p className="text-sm text-gray-600 mb-2">Cobertura: {r.cobertura}</p>
+            <p className="font-bold">${r.precio}</p>
+          </div>
         ))}
-      </ul>
+      </div>
     </div>
   );
 }

--- a/frontend/src/pages/Register.jsx
+++ b/frontend/src/pages/Register.jsx
@@ -1,9 +1,11 @@
 import { useState } from "react";
+import { useNavigate } from "react-router-dom";
 
 const Register = () => {
   const [name, setName] = useState("");
   const [email, setEmail] = useState("");
   const [password, setPassword] = useState("");
+  const navigate = useNavigate();
 
   const handleRegister = async (e) => {
     e.preventDefault();
@@ -19,6 +21,7 @@ const Register = () => {
       setName("");
       setEmail("");
       setPassword("");
+      navigate("/login");
     } else {
       alert(data.message || "Error al registrar");
     }

--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -2,5 +2,13 @@ import { defineConfig } from 'vite';
 import react from '@vitejs/plugin-react';
 
 export default defineConfig({
-  plugins: [react()]
+  plugins: [react()],
+  server: {
+    proxy: {
+      '/api': {
+        target: 'http://localhost:5000',
+        changeOrigin: true
+      }
+    }
+  }
 });


### PR DESCRIPTION
## Summary
- auto-detect free backend port if 5000 is busy
- update `.env.example` for local MongoDB port
- randomize recommendations and expand mock data
- redirect user after successful register
- enhance recommendations UI
- configure Vite proxy for API requests

## Testing
- `npm test` in `backend` *(fails: Missing script)*
- `npm test` in `frontend` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_685d87c1c274832dbce44133b12d648e