### PR TITLE
Implement user listing, filtering and password recovery

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,9 @@
 # Node dependencies
 node_modules
 
+# Uploaded files
+backend/uploads
+
 # Logs
 npm-debug.log*
 

--- a/README.md
+++ b/README.md
@@ -35,3 +35,24 @@ Las rutas principales del frontend son:
 - `/recommendations`
 
 Estas páginas deberían mostrarse sin errores una vez que ambos servicios estén activos.
+
+## Pruebas rápidas con Thunder Client
+
+Puedes verificar el registro de usuarios y la obtención de la lista con las siguientes peticiones en Thunder Client:
+
+**Registrar usuario**
+
+```
+POST http://localhost:5000/api/auth/register
+{
+  "name": "ejemplo",
+  "email": "ejemplo@email.com",
+  "password": "123456"
+}
+```
+
+**Listar usuarios**
+
+```
+GET http://localhost:5000/api/auth/usuarios
+```

--- a/backend/controllers/authController.js
+++ b/backend/controllers/authController.js
@@ -1,10 +1,17 @@
 const User = require('../models/User');
 const { generateToken, saveToken } = require('../utils/auth');
+const { v4: uuidv4 } = require('uuid');
+const bcrypt = require('bcrypt');
 
 exports.register = async (req, res) => {
   try {
     const { name, email, password } = req.body;
-    const user = new User({ name, email, password });
+    const existing = await User.findOne({ email });
+    if (existing) {
+      return res.status(400).json({ message: 'Correo ya registrado' });
+    }
+    const hashed = await bcrypt.hash(password, 10);
+    const user = new User({ name, email, password: hashed });
     await user.save();
     res.status(201).json({ message: 'Usuario registrado correctamente' });
   } catch (error) {
@@ -14,11 +21,47 @@ exports.register = async (req, res) => {
 
 async function login(req, res) {
   const { email, password } = req.body;
-  const user = await User.findOne({ email, password });
+  const user = await User.findOne({ email });
   if (!user) return res.status(401).json({ error: 'Credenciales invalidas' });
+  const match = await bcrypt.compare(password, user.password);
+  if (!match) return res.status(401).json({ error: 'Credenciales invalidas' });
   const token = generateToken();
   saveToken(token, user._id.toString());
   res.json({ token, name: user.name });
 }
 
 exports.login = login;
+
+exports.getUsers = async (req, res) => {
+  const users = await User.find({}, '-password');
+  res.json(users);
+};
+
+exports.forgotPassword = async (req, res) => {
+  const { email } = req.body;
+  const user = await User.findOne({ email });
+  if (!user) return res.status(404).json({ error: 'Usuario no encontrado' });
+
+  const token = uuidv4();
+  user.resetToken = token;
+  user.resetTokenExpiry = Date.now() + 10 * 60 * 1000; // 10 min
+  await user.save();
+
+  res.json({ message: 'Token de recuperación generado', token });
+};
+
+exports.resetPassword = async (req, res) => {
+  const { token, password } = req.body;
+  const user = await User.findOne({
+    resetToken: token,
+    resetTokenExpiry: { $gt: Date.now() }
+  });
+  if (!user) return res.status(400).json({ error: 'Token inválido o expirado' });
+
+  user.password = await bcrypt.hash(password, 10);
+  user.resetToken = undefined;
+  user.resetTokenExpiry = undefined;
+  await user.save();
+
+  res.json({ message: 'Contraseña actualizada con éxito' });
+};

--- a/backend/models/User.js
+++ b/backend/models/User.js
@@ -3,7 +3,9 @@ const mongoose = require('mongoose');
 const userSchema = new mongoose.Schema({
   name: String,
   email: { type: String, unique: true },
-  password: String
+  password: String,
+  resetToken: String,
+  resetTokenExpiry: Date
 });
 
 module.exports = mongoose.model('User', userSchema);

--- a/backend/package.json
+++ b/backend/package.json
@@ -12,7 +12,8 @@
     "bcrypt": "^5.1.0",
     "jsonwebtoken": "^9.0.0",
     "multer": "^1.4.5-lts.1",
-    "dotenv": "^16.3.1"
+    "dotenv": "^16.3.1",
+    "uuid": "^9.0.0"
   },
   "devDependencies": {
     "nodemon": "^2.0.22"

--- a/backend/routes/auth.js
+++ b/backend/routes/auth.js
@@ -1,8 +1,17 @@
 const express = require('express');
 const router = express.Router();
-const { register, login } = require('../controllers/authController');
+const {
+  register,
+  login,
+  getUsers,
+  forgotPassword,
+  resetPassword
+} = require('../controllers/authController');
 
 router.post('/register', register);
 router.post('/login', login);
+router.get('/usuarios', getUsers);
+router.post('/forgot-password', forgotPassword);
+router.post('/reset-password', resetPassword);
 
 module.exports = router;

--- a/backend/routes/polizas.js
+++ b/backend/routes/polizas.js
@@ -1,18 +1,38 @@
 const express = require('express');
 const router = express.Router();
 const multer = require('multer');
+const fs = require('fs');
+const path = require('path');
 const Poliza = require('../models/Poliza');
 const { auth } = require('../utils/auth');
 
-const upload = multer({ dest: 'uploads/' });
+const uploadDir = path.join(__dirname, '..', 'uploads');
+if (!fs.existsSync(uploadDir)) fs.mkdirSync(uploadDir);
 
-router.post('/', auth, upload.single('file'), async (req, res) => {
-  const poliza = await Poliza.create({
-    user: req.userId,
-    filename: req.file.originalname,
-    mimetype: req.file.mimetype
-  });
-  res.json(poliza);
+const storage = multer.diskStorage({
+  destination: (req, file, cb) => cb(null, uploadDir),
+  filename: (req, file, cb) => cb(null, Date.now() + '_' + file.originalname)
+});
+
+const fileFilter = (req, file, cb) => {
+  if (/pdf|png|jpg|jpeg/.test(file.mimetype)) cb(null, true);
+  else cb(new Error('Tipo de archivo no permitido'));
+};
+
+const upload = multer({ storage, fileFilter });
+
+router.post('/upload', auth, upload.single('archivo'), async (req, res) => {
+  try {
+    if (!req.file) return res.status(400).json({ error: 'Archivo no enviado' });
+    const poliza = await Poliza.create({
+      user: req.userId,
+      filename: req.file.filename,
+      mimetype: req.file.mimetype
+    });
+    res.json({ message: 'Archivo subido con éxito', nombre: req.file.filename });
+  } catch (err) {
+    res.status(500).json({ error: 'Error al procesar archivo' });
+  }
 });
 
 router.get('/', auth, async (req, res) => {

--- a/backend/routes/seguros.js
+++ b/backend/routes/seguros.js
@@ -13,4 +13,14 @@ router.get('/', (req, res) => {
   res.json(seguros);
 });
 
+router.post('/filtrar', (req, res) => {
+  const { tipo, cobertura, min, max } = req.body;
+  let segurosFiltrados = [...mock];
+  if (tipo) segurosFiltrados = segurosFiltrados.filter(s => s.tipo === tipo);
+  if (cobertura) segurosFiltrados = segurosFiltrados.filter(s => s.cobertura === cobertura);
+  if (min) segurosFiltrados = segurosFiltrados.filter(s => s.precio >= Number(min));
+  if (max) segurosFiltrados = segurosFiltrados.filter(s => s.precio <= Number(max));
+  res.json(segurosFiltrados);
+});
+
 module.exports = router;

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -7,6 +7,8 @@ import Dashboard from "./pages/Dashboard.jsx";
 import Recommendations from "./pages/Recommendations.jsx";
 import UploadPolicy from "./pages/UploadPolicy.jsx";
 import Contact from "./pages/Contact.jsx";
+import ForgotPassword from "./pages/ForgotPassword.jsx";
+import ResetPassword from "./pages/ResetPassword.jsx";
 import { useAuth } from "./context/AuthContext.jsx";
 
 function Navbar() {
@@ -40,6 +42,8 @@ function App() {
         <Route path="/recommendations" element={<Recommendations />} />
         <Route path="/upload-policy" element={<UploadPolicy />} />
         <Route path="/contact" element={<Contact />} />
+        <Route path="/forgot-password" element={<ForgotPassword />} />
+        <Route path="/reset-password" element={<ResetPassword />} />
       </Routes>
     </Router>
   );

--- a/frontend/src/pages/Dashboard.jsx
+++ b/frontend/src/pages/Dashboard.jsx
@@ -7,33 +7,50 @@ export default function Dashboard() {
   const [filters, setFilters] = useState({ tipo: '', cobertura: '', min: '', max: '' });
 
   const load = async () => {
-    const params = new URLSearchParams();
-    Object.entries(filters).forEach(([k,v]) => v && params.append(k, v));
-    const res = await fetch(`/api/seguros?${params}`);
+    const res = await fetch('/api/seguros/filtrar', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(filters)
+    });
     setSeguros(await res.json());
   };
 
   useEffect(() => { load(); }, []);
 
   const handleChange = e => setFilters({ ...filters, [e.target.name]: e.target.value });
-  const applyFilters = e => { e.preventDefault(); load(); };
+  const applyFilters = e => {
+    e.preventDefault();
+    if ((filters.min && isNaN(filters.min)) || (filters.max && isNaN(filters.max))) {
+      alert('Min y Max deben ser numéricos');
+      return;
+    }
+    load();
+  };
 
   return (
     <div className="p-4">
       <h1 className="text-xl font-bold mb-2">Bienvenido {userName}</h1>
       <h2 className="text-lg font-semibold mb-4">Listado de Seguros</h2>
       <form onSubmit={applyFilters} className="flex flex-wrap gap-2 mb-4">
-        <input name="tipo" placeholder="Tipo" className="border p-1" onChange={handleChange} />
-        <input name="cobertura" placeholder="Cobertura" className="border p-1" onChange={handleChange} />
-        <input name="min" placeholder="Min" className="border p-1" onChange={handleChange} />
-        <input name="max" placeholder="Max" className="border p-1" onChange={handleChange} />
-        <button className="bg-blue-500 text-white px-3" type="submit">Filtrar</button>
+        <input name="tipo" placeholder="Tipo" className="border p-2 rounded-lg shadow" onChange={handleChange} />
+        <input name="cobertura" placeholder="Cobertura" className="border p-2 rounded-lg shadow" onChange={handleChange} />
+        <input name="min" placeholder="Min" className="border p-2 rounded-lg shadow" onChange={handleChange} />
+        <input name="max" placeholder="Max" className="border p-2 rounded-lg shadow" onChange={handleChange} />
+        <button className="bg-blue-500 hover:bg-blue-600 text-white px-3 rounded-lg shadow" type="submit">Filtrar</button>
       </form>
-      <ul>
-        {seguros.map(s => (
-          <li key={s.id} className="border-b py-1">{s.name} - ${s.precio}</li>
-        ))}
-      </ul>
+      {seguros.length === 0 ? (
+        <p>No se encontraron seguros</p>
+      ) : (
+        <div className="grid gap-4 grid-cols-1 md:grid-cols-2 lg:grid-cols-3">
+          {seguros.map(s => (
+            <div key={s.id} className="border rounded-lg p-4 shadow bg-white">
+              <h3 className="font-semibold text-lg mb-1">{s.name}</h3>
+              <p className="text-sm">Cobertura: {s.cobertura}</p>
+              <p className="text-sm font-bold">Precio: ${s.precio}</p>
+            </div>
+          ))}
+        </div>
+      )}
     </div>
   );
 }

--- a/frontend/src/pages/ForgotPassword.jsx
+++ b/frontend/src/pages/ForgotPassword.jsx
@@ -1,0 +1,27 @@
+import { useState } from 'react';
+
+export default function ForgotPassword() {
+  const [email, setEmail] = useState('');
+  const [msg, setMsg] = useState('');
+
+  const handleSubmit = async e => {
+    e.preventDefault();
+    const res = await fetch('/api/auth/forgot-password', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ email })
+    });
+    const data = await res.json();
+    if (res.ok) setMsg(`${data.message}: ${data.token}`);
+    else setMsg(data.error || 'Error');
+  };
+
+  return (
+    <form onSubmit={handleSubmit} className="max-w-sm mx-auto p-4 flex flex-col gap-2">
+      <h1 className="text-xl font-bold text-center mb-2">🔒 Recuperar contraseña</h1>
+      {msg && <p className="text-blue-600 text-sm">{msg}</p>}
+      <input type="email" className="border p-2 rounded" placeholder="Correo" value={email} onChange={e => setEmail(e.target.value)} />
+      <button className="bg-blue-500 hover:bg-blue-600 text-white p-2 rounded" type="submit">Enviar</button>
+    </form>
+  );
+}

--- a/frontend/src/pages/Login.jsx
+++ b/frontend/src/pages/Login.jsx
@@ -33,6 +33,7 @@ export default function Login() {
       <input name="email" placeholder="Correo" onChange={handleChange} className="border p-2" />
       <input type="password" name="password" placeholder="Contraseña" onChange={handleChange} className="border p-2" />
       <button className="bg-blue-500 text-white p-2" type="submit">Entrar</button>
+      <a href="/forgot-password" className="text-sm text-blue-600 text-center">¿Olvidaste tu contraseña?</a>
     </form>
   );
 }

--- a/frontend/src/pages/Register.jsx
+++ b/frontend/src/pages/Register.jsx
@@ -5,6 +5,7 @@ const Register = () => {
   const [name, setName] = useState("");
   const [email, setEmail] = useState("");
   const [password, setPassword] = useState("");
+  const [message, setMessage] = useState("");
   const navigate = useNavigate();
 
   const handleRegister = async (e) => {
@@ -17,13 +18,13 @@ const Register = () => {
 
     const data = await res.json();
     if (res.ok) {
-      alert(data.message || "Usuario registrado");
+      setMessage(data.message || "Usuario registrado");
       setName("");
       setEmail("");
       setPassword("");
-      navigate("/login");
+      setTimeout(() => navigate("/login"), 1000);
     } else {
-      alert(data.message || "Error al registrar");
+      setMessage(data.message || "Error al registrar");
     }
   };
 
@@ -56,6 +57,9 @@ const Register = () => {
           <button type="submit" className="w-full bg-blue-500 hover:bg-blue-600 text-white py-2 rounded-lg font-semibold">
             Registrarse
           </button>
+          {message && (
+            <p className="text-center mt-2 text-sm text-blue-600">{message}</p>
+          )}
         </form>
       </div>
     </div>

--- a/frontend/src/pages/ResetPassword.jsx
+++ b/frontend/src/pages/ResetPassword.jsx
@@ -1,0 +1,34 @@
+import { useState } from 'react';
+
+export default function ResetPassword() {
+  const [form, setForm] = useState({ token: '', password: '', confirm: '' });
+  const [msg, setMsg] = useState('');
+
+  const handleChange = e => setForm({ ...form, [e.target.name]: e.target.value });
+
+  const handleSubmit = async e => {
+    e.preventDefault();
+    if (form.password !== form.confirm) {
+      setMsg('Las contraseñas no coinciden');
+      return;
+    }
+    const res = await fetch('/api/auth/reset-password', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ token: form.token, password: form.password })
+    });
+    const data = await res.json();
+    setMsg(res.ok ? data.message : data.error || 'Error');
+  };
+
+  return (
+    <form onSubmit={handleSubmit} className="max-w-sm mx-auto p-4 flex flex-col gap-2">
+      <h1 className="text-xl font-bold text-center mb-2">✉️ Restablecer contraseña</h1>
+      {msg && <p className="text-blue-600 text-sm">{msg}</p>}
+      <input name="token" className="border p-2 rounded" placeholder="Token" onChange={handleChange} />
+      <input name="password" type="password" className="border p-2 rounded" placeholder="Nueva contraseña" onChange={handleChange} />
+      <input name="confirm" type="password" className="border p-2 rounded" placeholder="Confirmar contraseña" onChange={handleChange} />
+      <button className="bg-blue-500 hover:bg-blue-600 text-white p-2 rounded" type="submit">Enviar</button>
+    </form>
+  );
+}

--- a/frontend/src/pages/UploadPolicy.jsx
+++ b/frontend/src/pages/UploadPolicy.jsx
@@ -5,6 +5,7 @@ export default function UploadPolicy() {
   const { token } = useAuth();
   const [file, setFile] = useState(null);
   const [list, setList] = useState([]);
+  const [msg, setMsg] = useState('');
 
   const load = async () => {
     const res = await fetch('/api/polizas', { headers: { Authorization: `Bearer ${token}` } });
@@ -17,22 +18,29 @@ export default function UploadPolicy() {
     e.preventDefault();
     if (!file) return;
     const fd = new FormData();
-    fd.append('file', file);
-    await fetch('/api/polizas', {
+    fd.append('archivo', file);
+    const res = await fetch('/api/polizas/upload', {
       method: 'POST',
       headers: { Authorization: `Bearer ${token}` },
       body: fd
     });
-    setFile(null);
-    load();
+    const data = await res.json();
+    if (res.ok) {
+      setMsg(data.message);
+      setFile(null);
+      load();
+    } else {
+      setMsg(data.error || 'Error al subir');
+    }
   };
 
   return (
     <div className="p-4">
       <form onSubmit={handleSubmit} className="mb-4 flex gap-2">
-        <input type="file" onChange={e => setFile(e.target.files[0])} />
-        <button className="bg-blue-500 text-white px-3" type="submit">Subir</button>
+        <input type="file" onChange={e => setFile(e.target.files[0])} className="border rounded-lg p-2" />
+        <button className="bg-blue-500 hover:bg-blue-600 text-white px-3 rounded-lg" type="submit">📤 Subir</button>
       </form>
+      {msg && <p className="mb-2 text-sm text-blue-600">{msg}</p>}
       <ul>
         {list.map(p => (
           <li key={p._id}>{p.filename} ({p.mimetype})</li>


### PR DESCRIPTION
## Summary
- add GET `/api/auth/usuarios` and password recovery logic
- prevent duplicate registrations
- implement POST `/api/seguros/filtrar`
- improve policy upload with file type validation
- show registration and filter results in UI
- add forgot/reset password pages
- document Thunder Client usage

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_685d8d9d69b4832d885cf320eb75e759