### PR TITLE
Update frontend proxy to port 5004

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Proyecto de ejemplo para ejecutar frontend y backend de forma local.
 1. Copiar el archivo `backend/.env.example` a `backend/.env` y ajustar las variables:
    ```
    MONGO_URI=mongodb://localhost/aiseguros
-   PORT=5000
+   PORT=5004
    ```
 2. Instalar dependencias y levantar el backend:
    ```bash
@@ -25,7 +25,7 @@ Proyecto de ejemplo para ejecutar frontend y backend de forma local.
    npm start
    ```
 
-El frontend quedará disponible en `http://localhost:5173` y enviará las peticiones al backend `http://localhost:5000` gracias a la configuración del proxy.
+El frontend quedará disponible en `http://localhost:5173` y enviará las peticiones al backend `http://localhost:5004` gracias a la configuración del proxy.
 
 Las rutas principales del frontend son:
 - `/login`
@@ -43,7 +43,7 @@ Puedes verificar el registro de usuarios y la obtención de la lista con las sig
 **Registrar usuario**
 
 ```
-POST http://localhost:5000/api/auth/register
+POST http://localhost:5004/api/auth/register
 {
   "name": "ejemplo",
   "email": "ejemplo@email.com",
@@ -54,6 +54,6 @@ POST http://localhost:5000/api/auth/register
 **Listar usuarios**
 
 ```
-GET http://localhost:5000/api/users
+GET http://localhost:5004/api/users
 Authorization: Bearer <token>
 ```

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -1,2 +1,2 @@
 MONGO_URI=mongodb://localhost:27017/aiseguros
-PORT=5000
+PORT=5004

--- a/backend/server.js
+++ b/backend/server.js
@@ -6,7 +6,7 @@ const dotenv = require("dotenv");
 dotenv.config();
 
 const app = express();
-let port = process.env.PORT ? Number(process.env.PORT) : 5000;
+let port = process.env.PORT ? Number(process.env.PORT) : 5004;
 
 // Rutas
 const authRoutes = require("./routes/auth");

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -2,7 +2,7 @@
   "name": "frontend",
   "version": "1.0.0",
   "private": true,
-  "proxy": "http://localhost:5000",
+  "proxy": "http://localhost:5004",
   "scripts": {
     "dev": "vite",
     "build": "vite build",

--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -6,7 +6,7 @@ export default defineConfig({
   server: {
     proxy: {
       '/api': {
-        target: 'http://localhost:5000',
+        target: 'http://localhost:5004',
         changeOrigin: true
       }
     }


### PR DESCRIPTION
## Summary
- point Vite proxy to backend on port 5004
- update `package.json` proxy setting
- adjust documentation and .env example to use port 5004
- change backend default port to 5004

## Testing
- `npm run build` *(fails: vite Permission denied)*

------
https://chatgpt.com/codex/tasks/task_e_685d934b9730832db03c8e09d6808040