### PR TITLE
Add password hashing and users listing endpoint

### DIFF
--- a/backend/controllers/authController.js
+++ b/backend/controllers/authController.js
@@ -23,8 +23,8 @@ async function login(req, res) {
   const { email, password } = req.body;
   const user = await User.findOne({ email });
   if (!user) return res.status(401).json({ error: 'Credenciales invalidas' });
-  const match = await bcrypt.compare(password, user.password);
-  if (!match) return res.status(401).json({ error: 'Credenciales invalidas' });
+  const isMatch = await bcrypt.compare(password, user.password);
+  if (!isMatch) return res.status(401).json({ error: 'Credenciales invalidas' });
   const token = generateToken();
   saveToken(token, user._id.toString());
   res.json({ token, name: user.name });
@@ -33,7 +33,7 @@ async function login(req, res) {
 exports.login = login;
 
 exports.getUsers = async (req, res) => {
-  const users = await User.find({}, '-password');
+  const users = await User.find().select('-password');
   res.json(users);
 };
 

--- a/backend/models/User.js
+++ b/backend/models/User.js
@@ -1,4 +1,5 @@
 const mongoose = require('mongoose');
+const bcrypt = require('bcrypt');
 
 const userSchema = new mongoose.Schema({
   name: String,
@@ -6,6 +7,13 @@ const userSchema = new mongoose.Schema({
   password: String,
   resetToken: String,
   resetTokenExpiry: Date
+});
+
+userSchema.pre('save', async function (next) {
+  if (!this.isModified('password')) return next();
+  const salt = await bcrypt.genSalt(10);
+  this.password = await bcrypt.hash(this.password, salt);
+  next();
 });
 
 module.exports = mongoose.model('User', userSchema);

--- a/backend/routes/auth.js
+++ b/backend/routes/auth.js
@@ -10,7 +10,7 @@ const {
 
 router.post('/register', register);
 router.post('/login', login);
-router.get('/usuarios', getUsers);
+router.get('/users', getUsers);
 router.post('/forgot-password', forgotPassword);
 router.post('/reset-password', resetPassword);
 


### PR DESCRIPTION
## Summary
- secure user passwords by hashing on save
- compare hashed password during login
- provide endpoint to list users without passwords
- expose `/users` route under auth

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_685d95f3ec6c832daedde662547e1dbe