### PR TITLE
Implement cotizaciones pages

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -4,6 +4,8 @@ import Home from "./pages/Home.jsx";
 import Login from "./pages/Login.jsx";
 import Register from "./pages/Register.jsx";
 import Dashboard from "./pages/Dashboard.jsx";
+import Cotizaciones from "./pages/Cotizaciones.jsx";
+import CotizacionesTipo from "./pages/CotizacionesTipo.jsx";
 import Recommendations from "./pages/Recommendations.jsx";
 import UploadPolicy from "./pages/UploadPolicy.jsx";
 import Contact from "./pages/Contact.jsx";
@@ -18,7 +20,7 @@ function Navbar() {
     <nav className="bg-white shadow px-4 py-3 mb-4">
       <ul className="flex flex-wrap gap-4 text-sm font-medium">
         <li><Link to="/">Inicio</Link></li>
-        {token && <li><Link to="/dashboard">Cotizaciones</Link></li>}
+        {token && <li><Link to="/cotizaciones">Cotizaciones</Link></li>}
         <li><Link to="/recommendations">Recomendaciones</Link></li>
         {token && <li><Link to="/upload-policy">Pólizas</Link></li>}
         <li><Link to="/contact">Contacto</Link></li>
@@ -40,6 +42,9 @@ function App() {
         <Route path="/login" element={<Login />} />
         <Route path="/register" element={<Register />} />
         <Route path="/dashboard" element={<Dashboard />} />
+        <Route path="/cotizaciones" element={<Cotizaciones />} />
+        <Route path="/cotizaciones/:tipo" element={<CotizacionesTipo />} />
+        <Route path="/cotizaciones/:tipo/:id" element={<SeguroDetalle />} />
         <Route path="/recommendations" element={<Recommendations />} />
         <Route path="/upload-policy" element={<UploadPolicy />} />
         <Route path="/seguro/:id" element={<SeguroDetalle />} />

--- a/frontend/src/data/segurosData.js
+++ b/frontend/src/data/segurosData.js
@@ -1,0 +1,22 @@
+const tipos = ["auto", "vida", "mascotas", "salud", "viajes", "hogar"]; 
+let id = 1; 
+const seguros = []; 
+tipos.forEach(tipo => {
+  for (let i = 1; i <= 20; i++) {
+    seguros.push({
+      id: id++,
+      tipo,
+      nombre: `Seguro ${tipo.charAt(0).toUpperCase() + tipo.slice(1)} ${i}`,
+      cobertura: ["basica", "amplia", "total"][i % 3],
+      precio: 150000 + i * 5000,
+      descripcion: `Cobertura completa para ${tipo}, plan ${i}.`,
+      beneficios: ["Asistencia 24/7", "Cobertura internacional", "Atención preferente"],
+      exclusiones: ["Uso comercial", "Eventos extremos"],
+      contacto: {
+        telefono: "+56987654321",
+        correo: "contacto@aiseguros.cl"
+      }
+    });
+  }
+});
+export default seguros;

--- a/frontend/src/pages/Cotizaciones.jsx
+++ b/frontend/src/pages/Cotizaciones.jsx
@@ -1,0 +1,36 @@
+import { useNavigate } from 'react-router-dom';
+
+const tiposSeguros = [
+  { tipo: "auto", nombre: "Seguro de Auto", icono: "🚗" },
+  { tipo: "vida", nombre: "Seguro de Vida", icono: "❤️" },
+  { tipo: "mascotas", nombre: "Seguro de Mascotas", icono: "🐶" },
+  { tipo: "salud", nombre: "Seguro de Salud", icono: "🏥" },
+  { tipo: "viajes", nombre: "Seguro de Viajes", icono: "✈️" },
+  { tipo: "hogar", nombre: "Seguro de Hogar", icono: "🏡" }
+];
+
+export default function Cotizaciones() {
+  const navigate = useNavigate();
+  const irA = (tipo) => navigate(`/cotizaciones/${tipo}`); // Navegar a /cotizaciones/${tipo}
+
+  return (
+    <div className="max-w-6xl mx-auto px-4 py-8">
+      <h1 className="text-2xl font-bold text-teal-800 mb-6">Cotizaciones</h1>
+      <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 gap-6">
+        {tiposSeguros.map(t => (
+          <div
+            key={t.tipo}
+            onClick={() => irA(t.tipo)}
+            className="bg-white rounded-xl shadow-md p-6 flex flex-col items-center cursor-pointer hover:shadow-lg transition"
+          >
+            <div className="text-4xl mb-2">{t.icono}</div>
+            <h3 className="text-lg font-semibold mb-4 text-gray-800 text-center">{t.nombre}</h3>
+            <button className="bg-emerald-600 hover:bg-emerald-700 text-white px-4 py-2 rounded-lg font-semibold">
+              Ver opciones
+            </button>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/pages/CotizacionesTipo.jsx
+++ b/frontend/src/pages/CotizacionesTipo.jsx
@@ -1,0 +1,80 @@
+import { useParams, Link } from 'react-router-dom';
+import { useState } from 'react';
+import segurosData from '../data/segurosData.js';
+
+export default function CotizacionesTipo() {
+  const { tipo } = useParams();
+  const segurosDelTipo = segurosData.filter(s => s.tipo === tipo);
+
+  const [filtroNombre, setFiltroNombre] = useState("");
+  const [filtroCobertura, setFiltroCobertura] = useState("");
+  const [filtroMin, setFiltroMin] = useState("");
+  const [filtroMax, setFiltroMax] = useState("");
+
+  const segurosFiltrados = segurosDelTipo.filter(seguro => {
+    const nombreCoincide = seguro.nombre.toLowerCase().includes(filtroNombre.toLowerCase());
+    const coberturaCoincide =
+      filtroCobertura === "" || seguro.cobertura.toLowerCase() === filtroCobertura.toLowerCase();
+    const precioCoincide =
+      (!filtroMin || seguro.precio >= parseInt(filtroMin)) &&
+      (!filtroMax || seguro.precio <= parseInt(filtroMax));
+    return nombreCoincide && coberturaCoincide && precioCoincide;
+  });
+
+  const formatCLP = n => new Intl.NumberFormat('es-CL').format(n);
+
+  return (
+    <div className="max-w-6xl mx-auto px-4 py-8">
+      <h1 className="text-2xl font-bold text-teal-800 mb-6 capitalize">Seguros de {tipo}</h1>
+      <div className="flex flex-wrap gap-4 bg-gray-50 p-4 rounded-md shadow mb-6">
+        <input
+          type="text"
+          placeholder="Buscar por nombre"
+          value={filtroNombre}
+          onChange={e => setFiltroNombre(e.target.value)}
+          className="border rounded px-2 py-1 w-60"
+        />
+        <select
+          value={filtroCobertura}
+          onChange={e => setFiltroCobertura(e.target.value)}
+          className="border rounded px-2 py-1 w-40"
+        >
+          <option value="">Cobertura</option>
+          <option value="basica">Básica</option>
+          <option value="amplia">Amplia</option>
+          <option value="total">Total</option>
+        </select>
+        <input
+          type="number"
+          placeholder="Precio mínimo"
+          value={filtroMin}
+          onChange={e => setFiltroMin(e.target.value)}
+          className="border rounded px-2 py-1 w-28"
+        />
+        <input
+          type="number"
+          placeholder="Precio máximo"
+          value={filtroMax}
+          onChange={e => setFiltroMax(e.target.value)}
+          className="border rounded px-2 py-1 w-28"
+        />
+      </div>
+
+      {segurosFiltrados.length === 0 ? (
+        <p className="text-gray-600">❌ No se encontraron resultados con los filtros aplicados.</p>
+      ) : (
+        <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
+          {segurosFiltrados.map(seguro => (
+            <div key={seguro.id} className="bg-white rounded-lg shadow-md p-4 hover:shadow-lg transition flex flex-col">
+              <h3 className="font-semibold text-lg mb-1 text-teal-700">{seguro.nombre}</h3>
+              <p className="text-sm mb-1 capitalize">Cobertura: {seguro.cobertura}</p>
+              <p className="text-sm mb-2">{seguro.descripcion}</p>
+              <p className="font-bold mb-3">${formatCLP(seguro.precio)}</p>
+              <Link to={`/cotizaciones/${tipo}/${seguro.id}`} className="mt-auto bg-emerald-600 hover:bg-emerald-700 text-white font-semibold py-2 px-4 rounded-lg text-center">Ver detalles</Link>
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/pages/SeguroDetalle.jsx
+++ b/frontend/src/pages/SeguroDetalle.jsx
@@ -1,33 +1,51 @@
-import { useEffect, useState } from 'react';
 import { useParams } from 'react-router-dom';
-import axios from 'axios';
+import segurosData from '../data/segurosData.js';
 
 export default function SeguroDetalle() {
   const { id } = useParams();
-  const [seguro, setSeguro] = useState(null);
+  const seguro = segurosData.find(s => s.id === parseInt(id));
 
-  useEffect(() => {
-    axios.get(`/api/seguros/${id}`).then(res => setSeguro(res.data));
-  }, [id]);
+  const formatCLP = n => new Intl.NumberFormat('es-CL').format(n);
 
-  const formatCLP = (n) => new Intl.NumberFormat('es-CL', { style: 'currency', currency: 'CLP' }).format(n);
-
-  if (!seguro) return <p className="p-4">Cargando...</p>;
+  if (!seguro) {
+    return <p className="p-4 text-center">Seguro no encontrado</p>;
+  }
 
   return (
-    <div className="p-4 max-w-3xl mx-auto bg-white shadow rounded-lg">
-      <h1 className="text-2xl font-bold mb-2 text-teal-700">{seguro.name}</h1>
-      <p className="mb-2">{seguro.descripcion}</p>
-      <p className="font-semibold mb-4">Precio: {formatCLP(seguro.precio)}</p>
-      <h2 className="font-semibold mb-1">Beneficios</h2>
-      <ul className="list-disc pl-5 mb-4">
-        {seguro.beneficios.map((b, i) => <li key={i}>{b}</li>)}
-      </ul>
-      <h2 className="font-semibold mb-1">Exclusiones</h2>
-      <ul className="list-disc pl-5 mb-6">
-        {seguro.exclusiones.map((e, i) => <li key={i}>{e}</li>)}
-      </ul>
-      <button className="bg-teal-600 hover:bg-teal-700 text-white px-4 py-2 rounded">Cotizar / Contactar</button>
+    <div className="max-w-2xl mx-auto px-4 py-8">
+      <div className="bg-white rounded-xl shadow-lg p-6">
+        <h1 className="text-3xl font-bold text-teal-800 mb-4">{seguro.nombre}</h1>
+        <p className="text-gray-700 mb-4">{seguro.descripcion}</p>
+        <p className="text-lg font-semibold text-gray-800 mb-2">Precio: ${formatCLP(seguro.precio)}</p>
+        <p className="capitalize mb-4">Cobertura: {seguro.cobertura}</p>
+        <h2 className="font-semibold mb-2 text-teal-700">Beneficios</h2>
+        <ul className="list-disc pl-5 mb-4 text-gray-700">
+          {seguro.beneficios.map((b, i) => <li key={i}>✔ {b}</li>)}
+        </ul>
+        <h2 className="font-semibold mb-2 text-teal-700">Exclusiones</h2>
+        <ul className="list-disc pl-5 text-gray-700">
+          {seguro.exclusiones.map((e, i) => <li key={i}>✖ {e}</li>)}
+        </ul>
+
+        <div className="mt-8 p-6 bg-teal-50 border border-teal-100 rounded-xl shadow-md">
+          <h2 className="text-2xl font-semibold text-teal-900 mb-4">Cotiza este seguro</h2>
+          <p className="text-gray-700 mb-2">
+            <strong>Teléfono:</strong>{' '}
+            <a href={`tel:${seguro.contacto.telefono}`} className="text-teal-800 hover:underline">
+              +56 9 8765 4321
+            </a>
+          </p>
+          <p className="text-gray-700 mb-4">
+            <strong>Correo:</strong>{' '}
+            <a href={`mailto:${seguro.contacto.correo}`} className="text-teal-800 hover:underline">
+              {seguro.contacto.correo}
+            </a>
+          </p>
+          <button className="bg-teal-600 hover:bg-teal-700 text-white font-semibold py-2 px-6 rounded-lg">
+            Quiero este seguro
+          </button>
+        </div>
+      </div>
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- add dataset with many insurance entries
- build new Cotizaciones page for insurance categories
- build CotizacionesTipo page with filtering and navigation
- redesign SeguroDetalle to show details and contact
- update routes and navbar

## Testing
- `npm run build` *(fails: vite: Permission denied)*

------
https://chatgpt.com/codex/tasks/task_e_685da6e9df50832da103fc5cdda8dc1a