### PR TITLE
Improve filters and contact UI

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -20,14 +20,30 @@ function Navbar() {
     <nav className="bg-white shadow px-4 py-3 mb-4">
       <ul className="flex flex-wrap gap-4 text-sm font-medium">
         <li><Link to="/">Inicio</Link></li>
-        <li><Link to="/cotizaciones">Cotizaciones</Link></li>
-        <li><Link to="/recommendations">Recomendaciones</Link></li>
+        <li>
+          <Link to="/cotizaciones">Cotizaciones</Link>
+        </li>
+        {token && <li><Link to="/recommendations">Recomendaciones</Link></li>}
         {token && <li><Link to="/upload-policy">Pólizas</Link></li>}
         <li><Link to="/contact">Contacto</Link></li>
-        {!token && <li><Link to="/login">Login</Link></li>}
-        {!token && <li><Link to="/register">Registro</Link></li>}
-        {token && <li>Hola, {userName}</li>}
-        {token && <li><button onClick={logout}>Logout</button></li>}
+        {!token && (
+          <>
+            <li>
+              <Link to="/login">Login</Link>
+            </li>
+            <li>
+              <Link to="/register">Registro</Link>
+            </li>
+          </>
+        )}
+        {token && (
+          <>
+            <li>👤 Bienvenido, {userName}</li>
+            <li>
+              <button onClick={logout}>Logout</button>
+            </li>
+          </>
+        )}
       </ul>
     </nav>
   );

--- a/frontend/src/pages/CotizacionesTipo.jsx
+++ b/frontend/src/pages/CotizacionesTipo.jsx
@@ -1,10 +1,29 @@
 import { useParams, Link } from 'react-router-dom';
 import { useState } from 'react';
 import segurosData from '../data/segurosData.js';
+import {
+  BENEFICIOS_POSIBLES,
+  EXCLUSIONES_POSIBLES
+} from '../data/filtrosOpciones.js';
 
 export default function CotizacionesTipo() {
   const { tipo } = useParams();
   const segurosDelTipo = segurosData.filter(s => s.tipo === tipo);
+
+  const coberturasUnicas = Array.from(
+    new Set(segurosDelTipo.map(s => s.cobertura))
+  );
+  const precios = segurosDelTipo.map(s => s.precio);
+  const minPrecio = Math.min(...precios);
+  const maxPrecio = Math.max(...precios);
+  const pasosPrecio = [];
+  for (
+    let p = Math.floor(minPrecio / 10000) * 10000;
+    p <= Math.ceil(maxPrecio / 10000) * 10000;
+    p += 10000
+  ) {
+    pasosPrecio.push(p);
+  }
 
   const [filtroNombre, setFiltroNombre] = useState("");
   const [filtroCobertura, setFiltroCobertura] = useState("");
@@ -55,41 +74,63 @@ export default function CotizacionesTipo() {
         <select
           value={filtroCobertura}
           onChange={e => setFiltroCobertura(e.target.value)}
-          className="border rounded px-2 py-1 w-40"
+          className="border rounded px-2 py-1 w-40 capitalize"
         >
           <option value="">Cobertura</option>
-          <option value="basica">Básica</option>
-          <option value="amplia">Amplia</option>
-          <option value="total">Total</option>
+          {coberturasUnicas.map(c => (
+            <option key={c} value={c} className="capitalize">
+              {c}
+            </option>
+          ))}
         </select>
-        <input
-          type="number"
-          placeholder="Precio mínimo"
-          value={filtroMin}
-          onChange={e => setFiltroMin(e.target.value)}
-          className="border rounded px-2 py-1 w-28"
-        />
-        <input
-          type="number"
-          placeholder="Precio máximo"
-          value={filtroMax}
-          onChange={e => setFiltroMax(e.target.value)}
-          className="border rounded px-2 py-1 w-28"
-        />
-        <input
-          type="text"
-          placeholder="Filtrar por beneficio"
+        <select
           value={filtroBeneficio}
           onChange={e => setFiltroBeneficio(e.target.value)}
           className="border rounded px-2 py-1 w-48"
-        />
-        <input
-          type="text"
-          placeholder="Filtrar por exclusión"
+        >
+          <option value="">Beneficio</option>
+          {BENEFICIOS_POSIBLES.map(b => (
+            <option key={b} value={b}>
+              {b}
+            </option>
+          ))}
+        </select>
+        <select
           value={filtroExclusion}
           onChange={e => setFiltroExclusion(e.target.value)}
           className="border rounded px-2 py-1 w-48"
-        />
+        >
+          <option value="">Exclusión</option>
+          {EXCLUSIONES_POSIBLES.map(e => (
+            <option key={e} value={e}>
+              {e}
+            </option>
+          ))}
+        </select>
+        <select
+          value={filtroMin}
+          onChange={e => setFiltroMin(e.target.value)}
+          className="border rounded px-2 py-1 w-28"
+        >
+          <option value="">Precio mínimo</option>
+          {pasosPrecio.map(p => (
+            <option key={p} value={p}>
+              {formatCLP(p)}
+            </option>
+          ))}
+        </select>
+        <select
+          value={filtroMax}
+          onChange={e => setFiltroMax(e.target.value)}
+          className="border rounded px-2 py-1 w-28"
+        >
+          <option value="">Precio máximo</option>
+          {pasosPrecio.map(p => (
+            <option key={p} value={p}>
+              {formatCLP(p)}
+            </option>
+          ))}
+        </select>
       </div>
 
       {segurosFiltrados.length === 0 ? (

--- a/frontend/src/pages/Home.jsx
+++ b/frontend/src/pages/Home.jsx
@@ -19,9 +19,14 @@ export default function Home() {
           <a href="/cotizaciones" className="bg-emerald-600 hover:bg-emerald-700 text-white px-6 py-2 rounded-lg shadow">
             Ver Cotizaciones
           </a>
-          <a href="/register" className="bg-white border border-emerald-600 text-emerald-600 hover:bg-emerald-100 px-6 py-2 rounded-lg shadow">
-            Crear Cuenta
-          </a>
+          {!token && (
+            <a
+              href="/login"
+              className="bg-white border border-emerald-600 text-emerald-600 hover:bg-emerald-100 px-6 py-2 rounded-lg shadow"
+            >
+              Iniciar Sesión
+            </a>
+          )}
         </div>
       </div>
     </main>

--- a/frontend/src/pages/Recommendations.jsx
+++ b/frontend/src/pages/Recommendations.jsx
@@ -1,41 +1,85 @@
 import { useState } from 'react';
+import { useAuth } from '../context/AuthContext.jsx';
+import segurosData from '../data/segurosData.js';
 
 export default function Recommendations() {
-  const [form, setForm] = useState({ edad: '', tipo: '' });
+  const { token } = useAuth();
+  const [filtros, setFiltros] = useState({ tipo: '', edad: '', presupuesto: '' });
   const [recs, setRecs] = useState([]);
 
-  const handleChange = e => setForm({ ...form, [e.target.name]: e.target.value });
+  const handleChange = e => setFiltros({ ...filtros, [e.target.name]: e.target.value });
 
-  const handleSubmit = async e => {
-    e.preventDefault();
-    const res = await fetch('/api/recomendaciones', {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({
-        edad: Number(form.edad),
-        tipo: form.tipo
-      })
-    });
-    setRecs(await res.json());
+  const filtrar = () => {
+    let lista = segurosData;
+    if (filtros.tipo) {
+      lista = lista.filter(s => s.tipo === filtros.tipo);
+    }
+    if (filtros.presupuesto) {
+      if (filtros.presupuesto === 'low') lista = lista.filter(s => s.precio < 100000);
+      if (filtros.presupuesto === 'mid') lista = lista.filter(s => s.precio >= 100000 && s.precio <= 200000);
+      if (filtros.presupuesto === 'high') lista = lista.filter(s => s.precio > 200000);
+    }
+    setRecs(lista.slice(0, 6));
   };
 
   return (
     <div className="p-4 max-w-xl mx-auto">
-      <form onSubmit={handleSubmit} className="flex flex-col sm:flex-row gap-2 mb-6">
-        <input
-          name="edad"
-          placeholder="Edad"
-          type="number"
-          onChange={handleChange}
-          className="border p-2 rounded flex-1"
-        />
-        <input
+      {!token && (
+        <p className="mb-4 text-sm text-orange-600">
+          🔒 Para obtener recomendaciones personalizadas, por favor inicia sesión.
+        </p>
+      )}
+      <form
+        onSubmit={e => {
+          e.preventDefault();
+          filtrar();
+        }}
+        className="flex flex-col gap-3 mb-6"
+      >
+        <select
           name="tipo"
-          placeholder="Tipo de seguro"
+          value={filtros.tipo}
           onChange={handleChange}
-          className="border p-2 rounded flex-1"
-        />
-        <button className="bg-blue-500 hover:bg-blue-600 text-white px-4 py-2 rounded" type="submit">Obtener</button>
+          className="border p-2 rounded"
+        >
+          <option value="">Tipo de seguro</option>
+          <option value="auto">Auto</option>
+          <option value="vida">Vida</option>
+          <option value="salud">Salud</option>
+          <option value="mascotas">Mascotas</option>
+          <option value="viajes">Viajes</option>
+          <option value="hogar">Hogar</option>
+        </select>
+        <select
+          name="edad"
+          value={filtros.edad}
+          onChange={handleChange}
+          className="border p-2 rounded"
+        >
+          <option value="">Edad</option>
+          <option value="18-25">18-25</option>
+          <option value="26-35">26-35</option>
+          <option value="36-45">36-45</option>
+          <option value="46-60">46-60</option>
+          <option value="60+">60+</option>
+        </select>
+        <select
+          name="presupuesto"
+          value={filtros.presupuesto}
+          onChange={handleChange}
+          className="border p-2 rounded"
+        >
+          <option value="">Presupuesto aproximado</option>
+          <option value="low">menos de $100.000</option>
+          <option value="mid">$100.000 - $200.000</option>
+          <option value="high">más de $200.000</option>
+        </select>
+        <button
+          className="bg-blue-500 hover:bg-blue-600 text-white px-4 py-2 rounded"
+          type="submit"
+        >
+          Filtrar
+        </button>
       </form>
       <div className="grid gap-4">
         {recs.map(r => (
@@ -46,6 +90,21 @@ export default function Recommendations() {
           </div>
         ))}
       </div>
+      {recs.length === 0 && (
+        <p className="text-center text-gray-600 mt-4">
+          😕 No encontramos seguros que coincidan con tus criterios. Prueba con otras combinaciones.
+        </p>
+      )}
+      {recs.length > 0 && (
+        <div className="text-center mt-6">
+          <a
+            href="/cotizaciones"
+            className="text-blue-600 underline hover:text-blue-800"
+          >
+            Ver todos los seguros
+          </a>
+        </div>
+      )}
     </div>
   );
 }

--- a/frontend/src/pages/SeguroDetalle.jsx
+++ b/frontend/src/pages/SeguroDetalle.jsx
@@ -1,9 +1,11 @@
 import { useParams } from 'react-router-dom';
+import { useState } from 'react';
 import segurosData from '../data/segurosData.js';
 
 export default function SeguroDetalle() {
   const { id } = useParams();
   const seguro = segurosData.find(s => s.id === parseInt(id));
+  const [mostrarContacto, setMostrarContacto] = useState(false);
 
   const formatCLP = n => new Intl.NumberFormat('es-CL').format(n);
 
@@ -29,21 +31,35 @@ export default function SeguroDetalle() {
 
         <div className="mt-8 p-6 bg-teal-50 border border-teal-100 rounded-xl shadow-md">
           <h2 className="text-2xl font-semibold text-teal-900 mb-4">Cotiza este seguro</h2>
-          <p className="text-gray-700 mb-2">
-            <strong>Teléfono:</strong>{' '}
-            <a href={`tel:${seguro.contacto.telefono}`} className="text-teal-800 hover:underline">
-              +56 9 8765 4321
-            </a>
-          </p>
-          <p className="text-gray-700 mb-4">
-            <strong>Correo:</strong>{' '}
-            <a href={`mailto:${seguro.contacto.correo}`} className="text-teal-800 hover:underline">
-              {seguro.contacto.correo}
-            </a>
-          </p>
-          <button className="bg-teal-600 hover:bg-teal-700 text-white font-semibold py-2 px-6 rounded-lg">
-            Quiero este seguro
+          <button
+            onClick={() => setMostrarContacto(true)}
+            className="bg-teal-600 hover:bg-teal-700 text-white font-semibold py-2 px-6 rounded-lg"
+          >
+            📞 Contactar ahora
           </button>
+          {mostrarContacto && (
+            <div className="mt-4 text-center bg-white p-4 rounded shadow">
+              <p className="text-gray-700">
+                <strong>Teléfono:</strong>{' '}
+                <a href={`tel:${seguro.contacto.telefono}`} className="text-teal-800 hover:underline">
+                  +56 9 8765 4321
+                </a>
+              </p>
+              <p className="text-gray-700">
+                <strong>Correo:</strong>{' '}
+                <a href={`mailto:${seguro.contacto.correo}`} className="text-teal-800 hover:underline">
+                  {seguro.contacto.correo}
+                </a>
+              </p>
+              <p className="text-sm mt-2">Nuestro equipo se pondrá en contacto contigo en menos de 24 horas.</p>
+              <button
+                onClick={() => setMostrarContacto(false)}
+                className="mt-3 text-blue-600 underline"
+              >
+                Cerrar
+              </button>
+            </div>
+          )}
         </div>
       </div>
     </div>


### PR DESCRIPTION
## Summary
- tweak homepage buttons to show login only when logged out
- update navbar greetings and conditional links
- reorder and change insurance filters to dropdowns
- revamp recommendations page with dropdowns and messages
- add contact-now modal on insurance detail page

## Testing
- `npm test` *(fails: Missing script)*
- `npm test` in backend *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_685db37c757c832d902710ead24a50d5