### PR TITLE
Implement policy comparison upload

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -13,7 +13,10 @@
     "jsonwebtoken": "^9.0.0",
     "mongoose": "^7.3.4",
     "multer": "^1.4.5-lts.1",
-    "uuid": "^9.0.1"
+    "uuid": "^9.0.1",
+    "mammoth": "^1.4.21",
+    "pdf-parse": "^1.1.1",
+    "string-similarity": "^4.0.4"
   },
   "devDependencies": {
     "nodemon": "^2.0.22"

--- a/backend/routes/polizaComparar.js
+++ b/backend/routes/polizaComparar.js
@@ -1,0 +1,68 @@
+const express = require('express');
+const multer = require('multer');
+const fs = require('fs');
+const path = require('path');
+const mammoth = require('mammoth');
+const pdfParse = require('pdf-parse');
+const stringSimilarity = require('string-similarity');
+
+const router = express.Router();
+const upload = multer({ dest: 'uploads/' });
+
+router.post('/comparar', upload.single('file'), async (req, res) => {
+  const filePath = req.file.path;
+  const ext = path.extname(req.file.originalname).toLowerCase();
+  let text = '';
+
+  try {
+    if (ext === '.docx') {
+      const result = await mammoth.extractRawText({ path: filePath });
+      text = result.value;
+    } else if (ext === '.pdf') {
+      const data = await fs.promises.readFile(filePath);
+      const result = await pdfParse(data);
+      text = result.text;
+    } else {
+      return res.status(400).json({ error: 'Formato no soportado' });
+    }
+
+    const tipoSeguro = extraerValor(text, /Tipo de seguro:\s*(.+)/i);
+    const cobertura = extraerValor(text, /Cobertura:\s*(.+)/i);
+    const precio = extraerValor(text, /Precio mensual:\s*(.+)/i);
+    const beneficios = extraerLista(text, /BENEFICIOS INCLUIDOS/i);
+    const exclusiones = extraerLista(text, /EXCLUSIONES/i);
+
+    const resultado = {
+      tipoSeguro,
+      cobertura,
+      precio,
+      beneficios,
+      exclusiones,
+    };
+
+    res.json({ resultado });
+  } catch (err) {
+    res.status(500).json({ error: 'Error procesando archivo' });
+  } finally {
+    fs.unlink(filePath, () => {});
+  }
+});
+
+function extraerValor(texto, regex) {
+  const match = texto.match(regex);
+  return match ? match[1].trim() : '';
+}
+
+function extraerLista(texto, titulo) {
+  const lines = texto.split('\n');
+  const index = lines.findIndex((line) => line.toLowerCase().includes(titulo.toLowerCase()));
+  if (index === -1) return [];
+  const result = [];
+  for (let i = index + 1; i < lines.length; i++) {
+    if (lines[i].startsWith('-')) result.push(lines[i].substring(1).trim());
+    else if (lines[i].trim() === '') break;
+  }
+  return result;
+}
+
+module.exports = router;

--- a/backend/server.js
+++ b/backend/server.js
@@ -15,6 +15,7 @@ const authRoutes = require("./routes/auth");
 const segurosRoutes = require("./routes/seguros");
 const recomendacionesRoutes = require("./routes/recomendaciones");
 const polizasRoutes = require("./routes/polizas");
+const polizaComparar = require("./routes/polizaComparar");
 const contactoRoutes = require("./routes/contacto");
 const usersRoutes = require("./routes/users");
 
@@ -38,6 +39,7 @@ app.use("/api/auth", authRoutes);
 app.use("/api/seguros", segurosRoutes);
 app.use("/api/recomendaciones", recomendacionesRoutes);
 app.use("/api/polizas", polizasRoutes);
+app.use("/api/polizas", polizaComparar);
 app.use("/api/contacto", contactoRoutes);
 app.use("/api/users", usersRoutes);
 

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -8,6 +8,7 @@ import Cotizaciones from "./pages/Cotizaciones.jsx";
 import CotizacionesTipo from "./pages/CotizacionesTipo.jsx";
 import Recommendations from "./pages/Recommendations.jsx";
 import UploadPolicy from "./pages/UploadPolicy.jsx";
+import CompararPoliza from "./pages/CompararPoliza.jsx";
 import Contact from "./pages/Contact.jsx";
 import SeguroDetalle from "./pages/SeguroDetalle.jsx";
 import ForgotPassword from "./pages/ForgotPassword.jsx";
@@ -25,6 +26,11 @@ function Navbar() {
         </li>
         {token && <li><Link to="/recommendations">Recomendaciones</Link></li>}
         {token && <li><Link to="/upload-policy">Pólizas</Link></li>}
+        {token && (
+          <li>
+            <Link to="/comparar-poliza">Comparar Póliza</Link>
+          </li>
+        )}
         <li><Link to="/contact">Contacto</Link></li>
         {!token && (
           <>
@@ -63,6 +69,7 @@ function App() {
         <Route path="/cotizaciones/:tipo/:id" element={<SeguroDetalle />} />
         <Route path="/recommendations" element={<Recommendations />} />
         <Route path="/upload-policy" element={<UploadPolicy />} />
+        <Route path="/comparar-poliza" element={<CompararPoliza />} />
         <Route path="/seguro/:id" element={<SeguroDetalle />} />
         <Route path="/contact" element={<Contact />} />
         <Route path="/forgot-password" element={<ForgotPassword />} />

--- a/frontend/src/pages/CompararPoliza.jsx
+++ b/frontend/src/pages/CompararPoliza.jsx
@@ -1,0 +1,91 @@
+import React, { useState } from "react";
+import axios from "axios";
+
+function CompararPoliza() {
+  const [file, setFile] = useState(null);
+  const [resultado, setResultado] = useState(null);
+  const [error, setError] = useState("");
+
+  const handleFileChange = (e) => {
+    const selected = e.target.files[0];
+    const allowed = [".docx", ".pdf"];
+    if (
+      selected &&
+      (allowed.includes(selected.name.slice(-5).toLowerCase()) ||
+        selected.name.endsWith(".pdf"))
+    ) {
+      setFile(selected);
+      setError("");
+    } else {
+      setFile(null);
+      setError("Solo se permiten archivos Word (.docx) o PDF");
+    }
+  };
+
+  const handleSubmit = async (e) => {
+    e.preventDefault();
+    if (!file) return;
+
+    const formData = new FormData();
+    formData.append("file", file);
+
+    try {
+      const res = await axios.post(
+        "http://localhost:5004/api/polizas/comparar",
+        formData
+      );
+      setResultado(res.data.resultado);
+    } catch (err) {
+      console.error(err);
+      setError("Error al procesar el archivo.");
+    }
+  };
+
+  return (
+    <div className="max-w-xl mx-auto mt-8 p-4 bg-white rounded shadow">
+      <h2 className="text-xl font-bold mb-4 text-center">📄 Comparar Póliza</h2>
+      <form onSubmit={handleSubmit}>
+        <input type="file" onChange={handleFileChange} className="mb-2" />
+        <button
+          type="submit"
+          className="bg-blue-600 text-white px-4 py-2 rounded hover:bg-blue-700"
+        >
+          Subir y comparar
+        </button>
+      </form>
+      {error && <p className="text-red-500 mt-2">{error}</p>}
+      {resultado && (
+        <div className="mt-6">
+          <h3 className="text-lg font-semibold">Resultado de comparación:</h3>
+          <p>
+            <strong>Tipo:</strong> {resultado.tipoSeguro}
+          </p>
+          <p>
+            <strong>Precio:</strong> {resultado.precio}
+          </p>
+          <p>
+            <strong>💠 Cobertura:</strong> {resultado.cobertura}
+          </p>
+          <div className="mt-2">
+            <strong>Beneficios:</strong>
+            <ul className="list-disc ml-5">
+              {resultado.beneficios.map((b, i) => (
+                <li key={i}>{b}</li>
+              ))}
+            </ul>
+          </div>
+          <div className="mt-2">
+            <strong>Exclusiones:</strong>
+            <ul className="list-disc ml-5">
+              {resultado.exclusiones.map((e, i) => (
+                <li key={i}>{e}</li>
+              ))}
+            </ul>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}
+
+export default CompararPoliza;


### PR DESCRIPTION
## Summary
- add mammoth, pdf-parse and string-similarity deps
- create `/api/polizas/comparar` route to parse uploaded files
- expose comparison route in server
- new `CompararPoliza` frontend page
- link new page in navbar and router

## Testing
- `npm test` *(fails: Missing script)*
- `npm run build` in frontend *(fails: vite permission denied)*

------
https://chatgpt.com/codex/tasks/task_e_685dbbb81944832d8c77c1e502919b86